### PR TITLE
Fixed spacing between buttons on homepage

### DIFF
--- a/weblate_web/media/style.css
+++ b/weblate_web/media/style.css
@@ -82,14 +82,14 @@ nav a {
     margin: 1em 0 1em 0;
 }
 .actions {
-    margin: 0 0 1em 0;
+    margin: 0;
     padding: 0;
 }
 .actions a {
     background-color: #cc0000;
     font-weight: bold;
     width: 16em;
-    margin: 0 2em 0 2em;
+    margin: 0 2em 1em 2em;
     display: inline-block;
     color: #fff;
     text-decoration: none;


### PR DESCRIPTION
When the browser window is not very wide, the buttons on home page sit right on top of each other with no spacing at all.

Screenshot: http://www.placella.com/temp/screenshot.png
