### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/weblate_web/context_processors.py
+++ b/weblate_web/context_processors.py
@@ -28,7 +28,7 @@ def weblate_web(request):
         url_name = 'home'
 
     downloads = [
-        'Weblate-%s.%s' % (VERSION, ext) for ext in EXTENSIONS
+        'Weblate-{0!s}.{1!s}'.format(VERSION, ext) for ext in EXTENSIONS
     ]
     return {
         'downloads': downloads,

--- a/weblate_web/templatetags/downloads.py
+++ b/weblate_web/templatetags/downloads.py
@@ -65,9 +65,9 @@ def downloadlink(name, text=None):
 
     size = filesizeformat(filesize)
 
-    return mark_safe('<a href="%(base)s%(name)s">%(text)s (%(size)s)</a>' % {
+    return mark_safe('<a href="{base!s}{name!s}">{text!s} ({size!s})</a>'.format(**{
         'base': settings.FILES_URL,
         'name': name,
         'text': text,
         'size': size,
-    })
+    }))

--- a/weblate_web/tests.py
+++ b/weblate_web/tests.py
@@ -38,8 +38,8 @@ class ViewTestCase(TestCase):
 
     def test_download_en(self):
         # create dummy files for testing
-        filenames = ['Weblate-%s.%s' % (VERSION, ext) for ext in EXTENSIONS]
-        filenames.append('Weblate-test-%s.tar.xz' % VERSION)
+        filenames = ['Weblate-{0!s}.{1!s}'.format(VERSION, ext) for ext in EXTENSIONS]
+        filenames.append('Weblate-test-{0!s}.tar.xz'.format(VERSION))
 
         temp_dir = tempfile.mkdtemp()
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:WeblateOrg:website?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:WeblateOrg:website?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)