### PR TITLE
Redundant "is"

### DIFF
--- a/weblate_web/templates/donate/form.html
+++ b/weblate_web/templates/donate/form.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% block title %}{% trans "Donate to Weblate" %}{% endblock %}
-{% block description %}{% trans "Weblate is does not require payment, and welcomes donations." %}{% endblock %}
+{% block description %}{% trans "Weblate does not require payment, and welcomes donations." %}{% endblock %}
 {% block content %}
 
 <section class="content">


### PR DESCRIPTION
The word "is" is not required in this case.