### PR TITLE
Automated backups link to regular backups section

### DIFF
--- a/weblate_web/templates/hosting.html
+++ b/weblate_web/templates/hosting.html
@@ -58,7 +58,7 @@
                             <span class="middle">{% trans "Priority e-mail support" %}</span>
                         </div>
                         <div class="line">
-                            <span class="middle">{% trans "Regular backups" %}</span>
+                            <span class="middle"><a href="https://docs.weblate.org/en/latest/admin/backup.html#automated-backup">{% trans "Regular backups" %}</a></span>
                         </div>
                         <div class="line">
                             <span class="middle"><a href="#dedicated">{% trans "Dedicated instance" %}</a></span>


### PR DESCRIPTION
Link to https://docs.weblate.org/en/latest/admin/backup.html#automated-backup for priority e-mail support
and
https://docs.weblate.org/en/latest/workflows.html#direct-translation for number of translators?

Eyes are drawn to the black text, and "number of translators" doesn't carry any important info.
The focus should be number of strings https://weblate.org/hosting/
Edit:
![bilde](https://user-images.githubusercontent.com/13802408/78969225-ff7a4200-7af5-11ea-9887-d4eb64d643e0.png)

![bilde](https://user-images.githubusercontent.com/13802408/78969072-a3afb900-7af5-11ea-8727-803b3d391da4.png)
vs
![bilde](https://user-images.githubusercontent.com/13802408/78969060-998dba80-7af5-11ea-9ed8-ee431b980f3b.png)