### PR TITLE
Spelling: Generated on -.

### DIFF
--- a/weblate_web/templates/mail/base.html
+++ b/weblate_web/templates/mail/base.html
@@ -250,7 +250,7 @@ img {
         </div>
         {% comment %}This avoids Gmail hiding the footer, as it finds unique content here{% endcomment %}
         {% now "DATETIME_FORMAT" as timestamp %}
-        <p style="opacity: 0" class="text-muted">{% blocktrans %}Generated on {{ timestamp }}.{% endblocktrans %}</p>
+        <p style="opacity: 0" class="text-muted">{% blocktrans %}Generated on {{ timestamp }}{% endblocktrans %}</p>
     </div>
     </div>
 {% endfilter %}


### PR DESCRIPTION
A better solution would be to use localized datetime based on user profile,
however the problem currently is the double-dotting ala
"Generated on April 12, 2020, 10:57 a.m.."