### PR TITLE
Libre plan wording reworked

### DIFF
--- a/weblate_web/templates/hosting.html
+++ b/weblate_web/templates/hosting.html
@@ -658,8 +658,7 @@
             <div class="libre-hosting">
               <h2>{% trans "Weblate proudly supports libre projects" %}</h2>
               <p>
-                {% blocktrans with url="https://hosted.weblate.org/hosting/" %}If you feel like being supported by Weblate will help your libre project, <a href="{{ url }}">set up your project</a>{% endblocktrans %}
-                {% blocktrans %}and get the <strong>Libre plan</strong> for gratis.{% endblocktrans %}
+                {% blocktrans with url="https://hosted.weblate.org/hosting/" %}If you feel like being supported by Weblate will help your libre project, <a href="{{ url }}">set up your project</a> and get the <strong>Libre plan</strong> gratis.{% endblocktrans %} 
                 {% blocktrans %}It has the same limits as the <strong>Advanced plan</strong>, but only for public projects.{% endblocktrans %}
             </p>
             </div>

--- a/weblate_web/templates/hosting.html
+++ b/weblate_web/templates/hosting.html
@@ -658,7 +658,7 @@
             <div class="libre-hosting">
               <h2>{% trans "Weblate proudly supports libre projects" %}</h2>
               <p>
-                {% blocktrans with url="https://hosted.weblate.org/hosting/" %}If you feel like being supported by Weblate will help your libre project, <a href="{{ url }}">set up your project</a> and get the <strong>Libre plan</strong> gratis.{% endblocktrans %} 
+                {% blocktrans with url="https://hosted.weblate.org/hosting/" %}If you feel like being supported by Weblate will help you, <a href="{{ url }}">set up your libre project</a> and get the <strong>Libre plan</strong> gratis.{% endblocktrans %} 
                 {% blocktrans %}It has the same limits as the <strong>Advanced plan</strong>, but only for public projects.{% endblocktrans %}
             </p>
             </div>

--- a/weblate_web/templates/hosting.html
+++ b/weblate_web/templates/hosting.html
@@ -652,15 +652,15 @@
             </div>
             <h2 class="section-title crypto payment-conditions" id="strings">{% trans "Source strings" %}</h2>
             <div class="page-desc small">
-                <p>{% trans "Pricing is based on number of source strings and target languages. The source string is a text unit defined in a translation format, it can be a word, sentence or paragraph." %}</p>
+                <p>{% trans "Pricing is based on the number of source strings and target languages. A source string is a text unit defined in a translation format, it can be a word, sentence or paragraph." %}</p>
             </div>
 
             <div class="libre-hosting">
-              <h2>{% trans "Weblate supports libre projects" %}</h2>
+              <h2>{% trans "Weblate proudly supports libre projects" %}</h2>
               <p>
-                {% blocktrans with url="https://hosted.weblate.org/hosting/" %}We proudly support open source projects across the globe. If you feel like being supported by Weblate will help your libre project, feel free to start free trial and <a href="{{ url }}">let us know</a>.{% endblocktrans %}
-                {% blocktrans %}For such projects, we would activate <strong>Libre plan</strong> for free.{% endblocktrans %}
-                {% blocktrans %}It has same limits as <strong>Advanced plan</strong>, but only allows public projects.{% endblocktrans %}
+                {% blocktrans with url="https://hosted.weblate.org/hosting/" %}If you feel like being supported by Weblate will help your libre project, <a href="{{ url }}">reach out</a>{% endblocktrans %}
+                {% blocktrans %}and get the <strong>Libre plan</strong> for gratis.{% endblocktrans %}
+                {% blocktrans %}It has the same limits as the <strong>Advanced plan</strong>, but only for public projects.{% endblocktrans %}
             </p>
             </div>
 

--- a/weblate_web/templates/hosting.html
+++ b/weblate_web/templates/hosting.html
@@ -652,7 +652,7 @@
             </div>
             <h2 class="section-title crypto payment-conditions" id="strings">{% trans "Source strings" %}</h2>
             <div class="page-desc small">
-                <p>{% trans "Pricing is based on the number of source strings and target languages. A source string is a text unit defined in a translation format, it can be a word, sentence or paragraph." %}</p>
+                <p>{% trans "Pricing is based on the number of source strings and target languages. A source string is a text unit defined in a translation format. It can be a word, sentence or paragraph." %}</p>
             </div>
 
             <div class="libre-hosting">

--- a/weblate_web/templates/hosting.html
+++ b/weblate_web/templates/hosting.html
@@ -658,7 +658,7 @@
             <div class="libre-hosting">
               <h2>{% trans "Weblate proudly supports libre projects" %}</h2>
               <p>
-                {% blocktrans with url="https://hosted.weblate.org/hosting/" %}If you feel like being supported by Weblate will help your libre project, <a href="{{ url }}">reach out</a>{% endblocktrans %}
+                {% blocktrans with url="https://hosted.weblate.org/hosting/" %}If you feel like being supported by Weblate will help your libre project, <a href="{{ url }}">set up your project</a>{% endblocktrans %}
                 {% blocktrans %}and get the <strong>Libre plan</strong> for gratis.{% endblocktrans %}
                 {% blocktrans %}It has the same limits as the <strong>Advanced plan</strong>, but only for public projects.{% endblocktrans %}
             </p>


### PR DESCRIPTION
Linking to the terms and services with "proudly" and to something explaining "libre" wouldn't be out of hand.