### PR TITLE
Spelling: React Intl, Vue I18n

### DIFF
--- a/weblate_web/templates/features.html
+++ b/weblate_web/templates/features.html
@@ -99,8 +99,8 @@
         	<a class="format-item" href="https://docs.weblate.org/en/latest/formats.html#js-i18next">{% trans "i18next" %} <span lang="en" dir="ltr">.json</span></a>
         	<a class="format-item" href="https://docs.weblate.org/en/latest/formats.html#webex">{% trans "WebExtension" %} <span lang="en" dir="ltr">.json</span></a>
         	<a class="format-item" href="https://docs.weblate.org/en/latest/formats.html#json">{% trans "Key and value" %} <span lang="en" dir="ltr">.json</span></a>
-        	<a class="format-item" href="https://docs.weblate.org/en/latest/formats.html#json">{% trans "react-intl" %} <span lang="en" dir="ltr">.json</span></a>
-        	<a class="format-item" href="https://docs.weblate.org/en/latest/formats.html#json">{% trans "vue-i18n" %} <span lang="en" dir="ltr">.json</span></a>
+        	<a class="format-item" href="https://docs.weblate.org/en/latest/formats.html#json">{% trans "React Intl" %} <span lang="en" dir="ltr">.json</span></a>
+        	<a class="format-item" href="https://docs.weblate.org/en/latest/formats.html#json">{% trans "Vue I18n" %} <span lang="en" dir="ltr">.json</span></a>
         	<a class="format-item" href="https://docs.weblate.org/en/latest/formats.html#go-i18n-json">go-i18n <span lang="en" dir="ltr">.json</span></a>
         	<a class="format-item" href="https://docs.weblate.org/en/latest/formats.html#arb">ARB <span lang="en" dir="ltr">.arb</span></a>
         	<a class="format-item" href="https://docs.weblate.org/en/latest/formats.html#php">{% trans "PHP" %} <span lang="en" dir="ltr">.php</span></a>


### PR DESCRIPTION
As per https://kazupon.github.io/vue-i18n/ and https://formatjs.io/docs/react-intl/