### PR TITLE
Spelling: One-time

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -157,7 +157,7 @@ RECURRENCE_CHOICES = [
     ("b", gettext_lazy("Biannual")),
     ("q", gettext_lazy("Quarterly")),
     ("m", gettext_lazy("Monthly")),
-    ("", gettext_lazy("Onetime")),
+    ("", gettext_lazy("One-time")),
 ]
 
 


### PR DESCRIPTION
As per https://grammarist.com/spelling/one-time-onetime/
Alternatives are "single", "one time" or "once", etc. Seems this just corrects the issue in spelling here, without causing
a departure in consistency between resources.

Spotted by @Geeyun-JY3 in https://hosted.weblate.org/translate/weblate/website/en/?checksum=53750295d9e47d6f#comments