### PR TITLE
Fix code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/weblate_web/views.py
+++ b/weblate_web/views.py
@@ -20,8 +20,8 @@
 from __future__ import annotations
 
 import json
-import random
 import logging
+import random
 
 import django.views.defaults
 import sentry_sdk
@@ -187,8 +187,10 @@ def api_hosted(request):
             salt="weblate.hosted",
         )
     except (BadSignature, SignatureExpired) as error:
-        logging.error("Error processing payment payload: %s", error)
-        return HttpResponseBadRequest("An error occurred while processing your request.")
+        logging.exception("Error processing payment payload: %s", error)
+        return HttpResponseBadRequest(
+            "An error occurred while processing your request."
+        )
 
     # Get/create service for this billing
     service = Service.objects.get_or_create(hosted_billing=payload["billing"])[0]

--- a/weblate_web/views.py
+++ b/weblate_web/views.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import random
+import logging
 
 import django.views.defaults
 import sentry_sdk
@@ -186,7 +187,8 @@ def api_hosted(request):
             salt="weblate.hosted",
         )
     except (BadSignature, SignatureExpired) as error:
-        return HttpResponseBadRequest(str(error))
+        logging.error("Error processing payment payload: %s", error)
+        return HttpResponseBadRequest("An error occurred while processing your request.")
 
     # Get/create service for this billing
     service = Service.objects.get_or_create(hosted_billing=payload["billing"])[0]


### PR DESCRIPTION
Fixes [https://github.com/WeblateOrg/website/security/code-scanning/3](https://github.com/WeblateOrg/website/security/code-scanning/3)

To fix the problem, we need to ensure that the detailed error message is not exposed to the end user. Instead, we should log the error message on the server and return a generic error message to the user. This can be achieved by using a logging mechanism to record the error details and modifying the HTTP response to return a generic message.

1. Import the `logging` module to log the error details.
2. Replace the line that returns `HttpResponseBadRequest(str(error))` with code that logs the error and returns a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
