### PR TITLE
fix: correcly use timedelta/relativedelta

### DIFF
--- a/weblate_web/models.py
+++ b/weblate_web/models.py
@@ -964,7 +964,7 @@ class Subscription(models.Model):
     def add_payment(self, invoice: Invoice, period: str):
         # Calculate new expiry
         start = self.expires + timedelta(days=1)
-        end = start + get_period_delta(period) - relativedelta(days=1)
+        end = start - timedelta(days=1) + get_period_delta(period)
 
         # Fetch customer object from last payment here
         if self.payment:


### PR DESCRIPTION

## Proposed changes

- using relativedelta for days results in unexpected results at the end of month
- correcly order mixed use of timedelta and relativedelta

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
