### PR TITLE
fix: sanitize extra value before saving

### DIFF
--- a/weblate_web/invoices/models.py
+++ b/weblate_web/invoices/models.py
@@ -351,6 +351,8 @@ class Invoice(models.Model):  # noqa: PLR0904
         using=None,
         update_fields=None,
     ) -> None:
+        if self.extra is None:
+            self.extra = {}
         extra_fields: list[str] = []
         if not self.due_date:
             self.due_date = self.issue_date + datetime.timedelta(


### PR DESCRIPTION
When empty string is passed in the admin, it should be coerced to an empty dict.

Fixes WEBSITE-AA
Fixes #2968

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
