### PR TITLE
Update "h2.section-title.hp-style" in style.css

### DIFF
--- a/weblate_web/static/style.css
+++ b/weblate_web/static/style.css
@@ -2911,10 +2911,10 @@ body.page .supporters {
 
 h2.section-title.hp-style {
   color: #2a3744;
-  font-size: 18px !important;
+  font-size: 40px !important;
   font-weight: 300;
   letter-spacing: 2px;
-  line-height: 23px;
+  line-height: 64px;
   margin-bottom: 40px;
   text-transform: uppercase;
 }


### PR DESCRIPTION
Increase the css `font-size` and `line-height` for the headlines **Robust feature set** and **Users and Supporters** on the homepage (https://weblate.org/). These are headlines, so IMO they should appear bigger.

In my former issue "Check font sizes #181" I already suggested to increse the font size of the class selector `h2.section-title.hp-style`.

My changes in the css for `h2.section-title.hp-style`:
Increased the `font-size` from 16px to 40px
Increased the `line-height` from 23px to 64px
