### PR TITLE
fix(subscription): prevent no-payment upgrades via GET flow

### DIFF
--- a/weblate_web/tests.py
+++ b/weblate_web/tests.py
@@ -4105,10 +4105,13 @@ class ServiceTest(FakturaceTestCase):
             )
 
             self.assertRedirects(response, reverse("user"))
-            self.assertContains(response, "Premium support")
+            self.assertContains(
+                response,
+                "Please confirm the upgrade from your account page.",
+            )
 
         subscription.refresh_from_db()
-        self.assertEqual(subscription.package, target)
+        self.assertNotEqual(subscription.package, target)
         self.assertEqual(subscription.payment, original_payment)
         self.assertEqual(subscription.expires, expires)
         self.assertEqual(Payment.objects.count(), 1)

--- a/weblate_web/views.py
+++ b/weblate_web/views.py
@@ -1141,7 +1141,12 @@ def subscription_new(request):
             for subscription in service.support_subscriptions:
                 if subscription.can_upgrade_to(package):
                     if not subscription.upgrade_requires_payment(package):
-                        subscription.upgrade_without_payment(package)
+                        messages.info(
+                            request,
+                            gettext(
+                                "Please confirm the upgrade from your account page."
+                            ),
+                        )
                         return redirect("user")
                     invoice = subscription.create_upgrade_invoice(
                         kind=InvoiceKind.DRAFT, package=package


### PR DESCRIPTION
### Motivation
- The `subscription_new` GET endpoint could perform a state-changing no-payment upgrade by calling `upgrade_without_payment`, which created a CSRFable path to change a user's subscription and future billing.

### Description
- Replaced the direct `subscription.upgrade_without_payment(package)` call in the `subscription_new` GET flow with an informational `messages.info(...)` and a redirect to the user page so upgrades must be confirmed via the existing POST-based flow (`subscription_upgrade`).
- Updated the regression test `test_subscription_new_support_upgrade_below_invoice_minimum` to assert the GET no longer upgrades the subscription and that the informational message is shown.
- Changes were made in `weblate_web/views.py` and the corresponding test in `weblate_web/tests.py` to keep upgrade execution protected by CSRF.

### Testing
- Ran the targeted test with `pytest weblate_web/tests.py -k subscription_new_support_upgrade_below_invoice_minimum`, which passed (1 passed, 168 deselected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13e8951ddc8329b6311d844ba873c2)