### PR TITLE
fix(saml): keep exact username matching in preloaded sync

### DIFF
--- a/weblate_web/saml.py
+++ b/weblate_web/saml.py
@@ -118,7 +118,7 @@ class SamlSyncContext:
         context = cls()
         providers_external_ids: dict[str, set[str]] = defaultdict(set)
         providers = set()
-        usernames = set()
+        usernames_exact = set()
         emails = set()
 
         for payload in payloads:
@@ -131,13 +131,13 @@ class SamlSyncContext:
                 providers_external_ids[provider].add(external_id)
             profile = extract_profile(payload)
             if username := profile.get("username"):
-                usernames.add(str(username).casefold())
+                usernames_exact.add(str(username))
             if email := profile.get("email"):
                 emails.add(str(email).casefold())
 
         context.preload_username_owners()
         context.preload_identities(providers_external_ids)
-        users = context.preload_legacy_users(usernames, emails)
+        users = context.preload_legacy_users(usernames_exact, emails)
         context.preload_user_identities(providers, users)
         return context
 
@@ -156,15 +156,11 @@ class SamlSyncContext:
                     self.add_identity(identity)
 
     def preload_legacy_users(
-        self, usernames: set[str], emails: set[str]
+        self, usernames_exact: set[str], emails: set[str]
     ) -> dict[int, User]:
         users: dict[int, User] = {}
-        for chunk in iter_chunks(usernames):
-            for username_user in (
-                User.objects.annotate(username_lower=Lower("username"))
-                .filter(username_lower__in=chunk)
-                .iterator()
-            ):
+        for chunk in iter_chunks(usernames_exact):
+            for username_user in User.objects.filter(username__in=chunk).iterator():
                 users[username_user.pk] = username_user
                 self.users_by_username[username_user.username.casefold()].append(
                     username_user

--- a/weblate_web/tests.py
+++ b/weblate_web/tests.py
@@ -3681,6 +3681,43 @@ class APITest(UserTestCase):
         )
         self.assertIn("possible action: link the correct local candidate", error_text)
 
+
+    @override_settings(HOSTED_USER_SYNC_API="https://hosted.example/users/")
+    @responses.activate
+    def test_sync_hosted_users_does_not_link_case_variant_username(self) -> None:
+        victim = User.objects.create_user(username="Victim", email="victim@example.com")
+        responses.add(
+            responses.POST,
+            "https://hosted.example/users/",
+            json={
+                "payload": dumps(
+                    {
+                        "cursor": "cursor-1",
+                        "users": [
+                            {
+                                "external_id": "42",
+                                "profile": {
+                                    "username": "victim",
+                                    "email": "new@example.com",
+                                },
+                            }
+                        ],
+                    },
+                    key=settings.PAYMENT_SECRET,
+                    salt="weblate.user-sync-response",
+                )
+            },
+        )
+
+        call_command("sync_hosted_users")
+
+        identity = SamlIdentity.objects.get(
+            provider="https://hosted.weblate.org/idp/metadata", external_id="42"
+        )
+        self.assertNotEqual(identity.user_id, victim.pk)
+        victim.refresh_from_db()
+        self.assertEqual(victim.username, "Victim")
+
     @override_settings(HOSTED_USER_SYNC_API="https://hosted.example/users/")
     @responses.activate
     def test_sync_hosted_users_only_missing(self) -> None:


### PR DESCRIPTION
### Motivation
- A change to the preloaded SAML sync cache made legacy username matching case-insensitive, allowing a hosted payload with a case-variant username to be linked to an existing local account and creating an unsafe `SamlIdentity` binding.
- The fix restores the previous safe semantics where legacy username candidate matching remains exact while keeping case-insensitive checks for other behaviors like email matching and username uniqueness.

### Description
- In `SamlSyncContext.preload` collect exact hosted usernames (store in `usernames_exact`) instead of casefolded names and pass those into `preload_legacy_users` to preserve exact-match semantics for username lookups.
- Change `SamlSyncContext.preload_legacy_users` to query `User.objects.filter(username__in=chunk)` (exact match) instead of annotating and comparing lowered usernames, while still indexing loaded users by `username.casefold()` for other context operations.
- Keep case-insensitive handling for emails and maintain username uniqueness helpers (`username_owner`) unchanged so uniqueness checks remain case-insensitive.
- Add a regression test `test_sync_hosted_users_does_not_link_case_variant_username` in `weblate_web/tests.py` that verifies a hosted payload with a case-variant username does not link to an existing local legacy account during the preloaded sync path.

### Testing
- Ran `pytest weblate_web/tests.py -k "does_not_link_case_variant_username or reports_candidate_links"` and both selected tests passed (2 passed, 197 deselected).
- Ran `mypy weblate_web/saml.py` with no issues reported.
- Ran `pylint weblate_web/saml.py` which returned a score of 10.00/10.
- `prek run --all-files` could not complete in this environment due to network restrictions when initializing hooks (GitHub clone failed with CONNECT tunnel 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a154f67776083298832c73b60777717)