### PR TITLE
fix(crm): require change permission for customer user invites

### DIFF
--- a/weblate_web/crm/templates/payments/customer_detail.html
+++ b/weblate_web/crm/templates/payments/customer_detail.html
@@ -52,12 +52,14 @@
       </label>
       <input type="submit" value="Review merge">
     </form>
-    <form method="post">
-      <p>{% translate "Add user to customer" %}</p>
-      {% csrf_token %}
-      {{ customer_user_form }}
-      <input type="submit" name="add_customer_user" value="{% translate "Add user" %}">
-    </form>
+    {% if can_add_customer_user %}
+      <form method="post">
+        <p>{% translate "Add user to customer" %}</p>
+        {% csrf_token %}
+        {{ customer_user_form }}
+        <input type="submit" name="add_customer_user" value="{% translate "Add user" %}">
+      </form>
+    {% endif %}
 
     <h2>Services</h2>
     {% include "weblate_web/service_list_content.html" with object_list=services %}

--- a/weblate_web/crm/tests.py
+++ b/weblate_web/crm/tests.py
@@ -313,6 +313,7 @@ class CRMTestCase(BaseCRMTestCase):
 
         response = self.client.get(customer.get_absolute_url())
 
+        self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, 'name="add_customer_user"')
 
     def test_customer_detail_rejects_add_customer_user_for_readonly_staff(self):
@@ -321,7 +322,11 @@ class CRMTestCase(BaseCRMTestCase):
             username="readonly", email="readonly@example.com", is_staff=True
         )
         readonly_user.user_permissions.add(
-            Permission.objects.get(codename="view_customer")
+            Permission.objects.get(
+                codename="view_customer",
+                content_type__app_label="payments",
+                content_type__model="customer",
+            )
         )
         self.client.force_login(readonly_user)
 

--- a/weblate_web/crm/tests.py
+++ b/weblate_web/crm/tests.py
@@ -297,6 +297,41 @@ class CRMTestCase(BaseCRMTestCase):
         self.assertContains(response, 'name="note"')
         self.assertContains(response, "Add note")
 
+    def test_customer_detail_hides_add_customer_user_for_readonly_staff(self):
+        customer = self.create_customer()
+        readonly_user = User.objects.create_user(
+            username="readonly", email="readonly@example.com", is_staff=True
+        )
+        readonly_user.user_permissions.add(
+            Permission.objects.get(codename="view_customer")
+        )
+        self.client.force_login(readonly_user)
+
+        response = self.client.get(customer.get_absolute_url())
+
+        self.assertNotContains(response, 'name="add_customer_user"')
+
+    def test_customer_detail_rejects_add_customer_user_for_readonly_staff(self):
+        customer = self.create_customer()
+        readonly_user = User.objects.create_user(
+            username="readonly", email="readonly@example.com", is_staff=True
+        )
+        readonly_user.user_permissions.add(
+            Permission.objects.get(codename="view_customer")
+        )
+        self.client.force_login(readonly_user)
+
+        response = self.client.post(
+            customer.get_absolute_url(),
+            {
+                "add_customer_user": "1",
+                "email": "new@example.com",
+                "full_name": "New User",
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+
     def test_customer_detail_adds_manual_note(self):
         customer = self.create_customer()
         note = (

--- a/weblate_web/crm/tests.py
+++ b/weblate_web/crm/tests.py
@@ -303,7 +303,11 @@ class CRMTestCase(BaseCRMTestCase):
             username="readonly", email="readonly@example.com", is_staff=True
         )
         readonly_user.user_permissions.add(
-            Permission.objects.get(codename="view_customer")
+            Permission.objects.get(
+                codename="view_customer",
+                content_type__app_label="payments",
+                content_type__model="customer",
+            )
         )
         self.client.force_login(readonly_user)
 

--- a/weblate_web/crm/views.py
+++ b/weblate_web/crm/views.py
@@ -545,9 +545,17 @@ class CustomerDetailView(CRMMixin, DetailView[Customer]):  # type: ignore[misc]
         context["customer_user_form"] = CustomerUserForm(
             self.request.POST if add_customer_user else None
         )
+        context["can_add_customer_user"] = self.request.user.has_perm(
+            "payments.change_customer"
+        )
         context["services"] = self.object.service_set.customer_services()
         context["donations"] = self.object.service_set.donations()
         return context
+
+    @staticmethod
+    def check_add_customer_user_permission(request) -> None:
+        if not request.user.has_perm("payments.change_customer"):
+            raise PermissionDenied
 
     def get_title(self) -> str:
         return self.object.verbose_name
@@ -642,6 +650,7 @@ class CustomerDetailView(CRMMixin, DetailView[Customer]):  # type: ignore[misc]
             return True
 
     def add_customer_user(self, request, customer: Customer, *args, **kwargs):
+        self.check_add_customer_user_permission(request)
         form = CustomerUserForm(request.POST)
         if not form.is_valid():
             show_form_errors(request, form)

--- a/weblate_web/crm/views.py
+++ b/weblate_web/crm/views.py
@@ -522,6 +522,7 @@ class CustomerListView(CRMMixin, ListView[Customer]):  # type: ignore[misc]
 class CustomerDetailView(CRMMixin, DetailView[Customer]):  # type: ignore[misc]
     model = Customer
     permission = "payments.view_customer"
+    add_customer_user_permission = "payments.change_customer"
     title = "Customer detail"
 
     def get_context_data(self, **kwargs):
@@ -546,15 +547,17 @@ class CustomerDetailView(CRMMixin, DetailView[Customer]):  # type: ignore[misc]
             self.request.POST if add_customer_user else None
         )
         context["can_add_customer_user"] = self.request.user.has_perm(
-            "payments.change_customer"
+            self.add_customer_user_permission
         )
         context["services"] = self.object.service_set.customer_services()
         context["donations"] = self.object.service_set.donations()
         return context
 
-    @staticmethod
-    def check_add_customer_user_permission(request) -> None:
-        if not request.user.has_perm("payments.change_customer"):
+    @classmethod
+    def check_add_customer_user_permission(
+        cls, request: AuthenticatedHttpRequest
+    ) -> None:
+        if not request.user.has_perm(cls.add_customer_user_permission):
             raise PermissionDenied
 
     def get_title(self) -> str:


### PR DESCRIPTION
### Motivation
- The customer detail view exposed a mutating `add_customer_user` POST action while the view was protected only by the read permission `payments.view_customer`, allowing read-only staff to provision/link users to customers.
- Customer.users membership grants access to sensitive self-service data, so adding users must require a stronger write-level permission.
- The change aims to prevent privilege escalation by requiring an explicit write permission before performing the invite/link operation.

### Description
- Require `payments.change_customer` before executing the `add_customer_user` mutation by adding a `check_add_customer_user_permission` guard in `weblate_web/crm/views.py` and calling it at the start of `add_customer_user`.
- Add a context flag `can_add_customer_user` in `CustomerDetailView.get_context_data` to expose whether the current user has the change permission.
- Hide the Add-user form in `weblate_web/crm/templates/payments/customer_detail.html` unless `can_add_customer_user` is true.
- Add two regression tests in `weblate_web/crm/tests.py` verifying that a read-only staff user (with only `view_customer`) does not see the form and receives HTTP 403 when POSTing the add action.

### Testing
- Ran `pytest -q weblate_web/crm/tests.py -k 'readonly_staff or adds_hosted_user'` and the selected tests passed: `3 passed, 93 deselected`.
- The hosted-user invite tests exercised the successful invite path and still pass under the new permission guard when executed with a user that has the required permissions.
- No other test suites were run as part of this change; the modification is intentionally minimal to restrict authorization for the new mutation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15bec6de388329aa10b1d844c15234)