### PR TITLE
refactor(saml): expose identifier extraction helper

### DIFF
--- a/weblate_web/saml.py
+++ b/weblate_web/saml.py
@@ -374,19 +374,23 @@ def sync_saml_payload(
     )
 
 
+def extract_user_identifier_params(session_info: dict) -> tuple[str, str | None]:
+    name_id = session_info.get("name_id")
+    if name_id is None:
+        LOGGER.error("The nameid is not available.")
+        return "external_id", None
+    external_id = normalize_external_id(name_id.text)
+    if not external_id:
+        LOGGER.error("The nameid text is not available.")
+        return "external_id", None
+    return "external_id", external_id
+
+
 class HostedSaml2Backend(Saml2Backend):
     def _extract_user_identifier_params(
         self, session_info: dict, attributes: dict, attribute_mapping: dict
     ) -> tuple[str, str | None]:
-        name_id = session_info.get("name_id")
-        if name_id is None:
-            LOGGER.error("The nameid is not available.")
-            return "external_id", None
-        external_id = normalize_external_id(name_id.text)
-        if not external_id:
-            LOGGER.error("The nameid text is not available.")
-            return "external_id", None
-        return "external_id", external_id
+        return extract_user_identifier_params(session_info)
 
     def get_or_create_user(  # noqa: PLR0913,PLR0917
         self,

--- a/weblate_web/tests.py
+++ b/weblate_web/tests.py
@@ -76,7 +76,11 @@ from .remote import (
     get_contributors,
     get_release,
 )
-from .saml import HostedSaml2Backend, get_username_max_length, sync_saml_identity
+from .saml import (
+    extract_user_identifier_params,
+    get_username_max_length,
+    sync_saml_identity,
+)
 from .templatetags.downloads import downloadlink, filesizeformat
 from .templatetags.prices import price_format
 from .utils import FOSDEM_ORIGIN, PAYMENTS_ORIGIN
@@ -3486,23 +3490,17 @@ class APITest(UserTestCase):
         self.assertEqual(user.password, old_password)
 
     def test_saml_backend_rejects_empty_nameid(self) -> None:
-        backend = HostedSaml2Backend()
-
         self.assertEqual(
-            backend._extract_user_identifier_params(  # pylint: disable=protected-access
-                {"name_id": SimpleNamespace(text=None)}, {}, {}
-            ),
+            extract_user_identifier_params({"name_id": SimpleNamespace(text=None)}),
             ("external_id", None),
         )
         self.assertEqual(
-            backend._extract_user_identifier_params(  # pylint: disable=protected-access
-                {"name_id": SimpleNamespace(text=" ")}, {}, {}
-            ),
+            extract_user_identifier_params({"name_id": SimpleNamespace(text=" ")}),
             ("external_id", None),
         )
         self.assertEqual(
-            backend._extract_user_identifier_params(  # pylint: disable=protected-access
-                {"name_id": SimpleNamespace(text="hosted-user-42")}, {}, {}
+            extract_user_identifier_params(
+                {"name_id": SimpleNamespace(text="hosted-user-42")}
             ),
             ("external_id", "hosted-user-42"),
         )


### PR DESCRIPTION
### Motivation

- Reduce occurrences of the `SLF001` / `protected-access` pattern by providing a public helper for extracting SAML NameID values instead of calling a backend's protected method in tests.

### Description

- Add a public helper `extract_user_identifier_params(session_info: dict) -> tuple[str, str | None]` in `weblate_web/saml.py` that encapsulates NameID extraction and logging.
- Make `HostedSaml2Backend._extract_user_identifier_params` delegate to the new `extract_user_identifier_params` helper.
- Update the SAML NameID regression test in `weblate_web/tests.py` to call `extract_user_identifier_params(...)` instead of invoking the backend's protected method, and remove the now-unused import.

### Testing

- Ran `ruff check weblate_web/saml.py weblate_web/tests.py` and fixed lint findings in the changed files; the checks passed for the modified files.
- Ran `ruff check --select SLF001 --statistics weblate_web` and confirmed a reduction in `SLF001` private-member-access instances for the targeted case.
- Ran `mypy weblate_web/` with no type issues reported.
- Ran `pylint weblate_web/` which completed successfully (score reported without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a363eeeb0448329abf6ff74d8b44ce1)