### PR TITLE
fix(invoices): include buyer PO reference in e-invoices

### DIFF
--- a/weblate_web/invoices/models.py
+++ b/weblate_web/invoices/models.py
@@ -902,6 +902,7 @@ class Invoice(models.Model):  # noqa: PLR0904
             payment_reference=payment_reference,
             payment_means=payment_means,
             payment_terms=payment_terms,
+            buyer_order_id=self.customer_reference or None,
             line_total_amount=line_total_amount,
             line_items=line_items,
             type_code=type_code,

--- a/weblate_web/invoices/tests.py
+++ b/weblate_web/invoices/tests.py
@@ -11,6 +11,7 @@ import responses
 from django.test.utils import override_settings
 from drafthorse.utils import validate_xml  # type: ignore[import-untyped]
 from lxml import etree
+from pycheval import generate_xml
 from pycheval.quantities import QuantityCode
 
 from weblate_web.models import Package, PackageCategory
@@ -180,6 +181,35 @@ class InvoiceTestCase(UserTestCase):
             self.assertEqual(response.status_code, 200, response.text)
             result = response.json()
             self.assertEqual(result["result"], "SUCCESS", result["reports"])
+
+    def get_einvoice_xml_tree(self, invoice: Invoice) -> etree._Element:
+        return etree.fromstring(generate_xml(invoice.get_en_16931_xml()).encode())
+
+    def test_customer_reference_is_buyer_order_reference(self) -> None:
+        invoice = self.create_invoice(customer_reference="PO123456")
+        root = self.get_einvoice_xml_tree(invoice)
+
+        buyer_order = root.find(
+            ".//ram:ApplicableHeaderTradeAgreement/"
+            "ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID",
+            EN16931Validator().namespaces,
+        )
+
+        self.assertIsNotNone(buyer_order)
+        if buyer_order is None:
+            self.fail("Buyer order reference is missing")
+        self.assertEqual(buyer_order.text, "PO123456")
+
+    def test_empty_customer_reference_omits_buyer_order_reference(self) -> None:
+        invoice = self.create_invoice()
+        root = self.get_einvoice_xml_tree(invoice)
+
+        buyer_order = root.find(
+            ".//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument",
+            EN16931Validator().namespaces,
+        )
+
+        self.assertIsNone(buyer_order)
 
     def mock_requests(self) -> None:
         mock_vies()


### PR DESCRIPTION
Map customer references to BT-13 so recipients can route e-invoices by purchase order.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
