### PR TITLE
fix(invoices): handle paginated invoice PDFs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ jobs:
       run: playwright install --with-deps chromium
 
     - name: Install PDF screenshot tools
-      run: sudo apt-get update && sudo apt-get install --no-install-recommends --yes poppler-utils
+      run: sudo apt-get update && sudo apt-get install --no-install-recommends --yes ghostscript
 
     - name: Create database
       run: ./manage.py migrate

--- a/weblate_web/invoices/models.py
+++ b/weblate_web/invoices/models.py
@@ -73,7 +73,7 @@ from weblate_web.const import (
     COMPANY_ZIP,
 )
 from weblate_web.exchange_rates import ExchangeRates
-from weblate_web.pdf import render_pdf
+from weblate_web.pdf import count_pdf_pages, render_pdf
 from weblate_web.utils import get_site_url
 
 if TYPE_CHECKING:
@@ -545,13 +545,16 @@ class Invoice(models.Model):  # noqa: PLR0904
             return self.all_items[0].description
         return ""
 
-    def render_html(self, *, is_receipt: bool = False) -> str:
+    def render_html(
+        self, *, is_receipt: bool = False, show_page_marker: bool = False
+    ) -> str:
         with override("en_GB"):
             return render_to_string(
                 "invoice-template.html",
                 {
                     "invoice": self,
                     "is_receipt": is_receipt,
+                    "show_page_marker": show_page_marker,
                     "company_name": COMPANY_NAME,
                     "company_address": COMPANY_ADDRESS,
                     "company_zip": COMPANY_ZIP,
@@ -964,8 +967,11 @@ class Invoice(models.Model):  # noqa: PLR0904
         """Render invoice as PDF."""
         # Create directory to store invoices
         settings.INVOICES_PATH.mkdir(exist_ok=True)
+        html = self.render_html(is_receipt=is_receipt)
+        if count_pdf_pages(html=html) > 1:
+            html = self.render_html(is_receipt=is_receipt, show_page_marker=True)
         render_pdf(
-            html=self.render_html(is_receipt=is_receipt),
+            html=html,
             output=settings.INVOICES_PATH / filename,
             attachments=attachments,
             factur_x=bool(attachments),

--- a/weblate_web/invoices/templates/invoice-template.html
+++ b/weblate_web/invoices/templates/invoice-template.html
@@ -13,306 +13,310 @@
   </head>
 
   <body>
-    <header>
-      <img class="logo" src="invoices:invoice-logo.svg" alt="Weblate">
-      <h1>
-        {% if is_receipt %}
-          Receipt for invoice number
-        {% else %}
-          {{ invoice.get_kind_display }} number
-        {% endif %}
-        {{ invoice.number }}
-      </h1>
-      <p>{{ invoice.issue_date|date }}</p>
-    </header>
+    <div class="invoice-page{% if show_page_marker %} with-page-marker{% endif %}">
+      <main>
+        <header>
+          <img class="logo" src="invoices:invoice-logo.svg" alt="Weblate">
+          <h1>
+            {% if is_receipt %}
+              Receipt for invoice number
+            {% else %}
+              {{ invoice.get_kind_display }} number
+            {% endif %}
+            {{ invoice.number }}
+          </h1>
+          <p>{{ invoice.issue_date|date }}</p>
+        </header>
 
-    <div id="contacts" class="fullwidth">
-      <address id="to">
-        <h2>
-          {% if is_receipt %}
-            Receipt for
-          {% elif invoice.is_draft %}
-            Quote for
-          {% else %}
-            Invoice to
-          {% endif %}
-        </h2>
-        {{ invoice.customer.name }}
-        <br />
-        {% if invoice.customer.contact_point %}
-          Contact: {{ invoice.customer.contact_point }}
-          <br />
-        {% endif %}
-        {{ invoice.customer.address }}
-        <br />
-        {% if invoice.customer.address_2 %}
-          {{ invoice.customer.address_2 }}
-          <br />
-        {% endif %}
-        {{ invoice.customer.postcode }} {{ invoice.customer.city }}
-        <br />
-        {{ invoice.customer.country.name }}
-        <br />
-        {% if invoice.customer.vat %}
-          VAT ID: {{ invoice.customer.vat }}
-          <br />
-        {% endif %}
-        {% if invoice.customer.tax %}
-          Reg: {{ invoice.customer.tax }}
-          <br />
-        {% endif %}
-      </address>
-
-      <address id="from">
-        <h2>Issued by</h2>
-        {{ company_name }}
-        <br />
-        {{ company_address }}
-        <br />
-        {{ company_zip }} {{ company_city }}
-        <br />
-        {{ company_country }}
-        <br />
-        VAT ID: {{ company_vat_id }}
-      </address>
-    </div>
-
-    {% if invoice.customer_reference %}
-      <p>Customer reference: {{ invoice.customer_reference }}</p>
-    {% endif %}
-    {% if invoice.customer_note %}
-      <div class="customer_note">{{ invoice.customer_note|linebreaks }}</div>
-    {% endif %}
-
-    <table id="items">
-      <thead>
-        <tr>
-          <th>Description</th>
-          <th>Quantity</th>
-          <th>Rate</th>
-          <th>Subtotal</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for item in invoice.all_items %}
-          <tr>
-            <td>
-              {{ item.description }}
-              {% if item.has_date_range %}<em class="period">{{ item.get_date_range_display }}</em>{% endif %}
-            </td>
-            <td>{{ item.display_quantity }}</td>
-            <td>{{ item.display_price }}</td>
-            <td>{{ item.display_total_price }}</td>
-          </tr>
-        {% endfor %}
-        {% if invoice.discount %}
-          <tr>
-            <td>{{ invoice.discount.description }}</td>
-            <td></td>
-            <td>{{ invoice.discount.display_percents }}</td>
-            <td>{{ invoice.display_total_discount }}</td>
-          </tr>
-        {% endif %}
-      </tbody>
-      <tfoot>
-        {% if invoice.vat_rate and invoice.is_final %}
-          <tr>
-            <td>Exchange rate for VAT</td>
-            <td></td>
-            <td>{{ invoice.exchange_rate_czk }} Kč</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td>Total excluding VAT</td>
-            <td></td>
-            <td>{{ invoice.total_amount_no_vat_czk }} Kč</td>
-            <td>{{ invoice.display_total_amount_no_vat }}</td>
-          </tr>
-          <tr>
-            <td>VAT {{ invoice.vat_rate }}%</td>
-            <td></td>
-            <td>{{ invoice.total_vat_czk }} Kč</td>
-            <td>{{ invoice.display_total_vat }}</td>
-          </tr>
-          <tr class="subtotal">
-            <td>Total including VAT</td>
-            <td></td>
-            <td>{{ invoice.total_amount_czk }} Kč</td>
-            <td>{{ invoice.display_total_amount }}</td>
-          </tr>
-        {% else %}
-          <tr>
-            <td>
-              VAT {{ invoice.vat_rate }}%
-              {% if not invoice.vat_rate %}
-                –
-                {% if invoice.customer.is_eu %}
-                  Reverse charge
-                {% else %}
-                  Place of supply outside EU
-                {% endif %}
-              {% endif %}
-            </td>
-            <td></td>
-            <td></td>
-            <td>{{ invoice.display_total_vat }}</td>
-          </tr>
-          <tr>
-            <td>Grand total</td>
-            <td></td>
-            <td></td>
-            <td>{{ invoice.display_total_amount }}</td>
-          </tr>
-        {% endif %}
-      </tfoot>
-    </table>
-
-    <footer>
-      <table id="total" class="fullwidth">
-        <thead>
-          <tr>
-            <th>
-              {% if invoice.is_draft %}
-                Quote amount
-              {% elif is_receipt %}
-                Amount
-              {% else %}
-                Total due
-              {% endif %}
-            </th>
-            <th>
+        <div id="contacts" class="fullwidth">
+          <address id="to">
+            <h2>
               {% if is_receipt %}
-                Paid on
+                Receipt for
               {% elif invoice.is_draft %}
-                Valid until
+                Quote for
               {% else %}
-                Due by
+                Invoice to
               {% endif %}
-            </th>
-            <th>Payment</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <strong>{{ invoice.display_total_amount }}</strong>
-            </td>
-            <td>
-              {% if is_receipt %}
-                {{ invoice.get_payment.created|date }}
-              {% else %}
-                {{ invoice.due_date|date }}
-              {% endif %}
-            </td>
-            <td>
-              {% if invoice.is_draft %}
-                Bank transfer or card payments are available
-              {% elif invoice.prepaid or is_receipt %}
-                {% if not is_receipt %}Do not pay, already paid{% endif %}
-                <div class="method">
-                  {% for payment in invoice.paid_payment_set.all %}
-                    {{ payment.get_payment_description }}
-                    <div class="uuid">{{ payment.pk }}</div>
-                  {% endfor %}
-                </div>
-              {% else %}
-                Bank transfer
-                <br />
-                {% for item, value in invoice.bank_account.get_short_info %}
-                  {{ item }}: {{ value }}
+            </h2>
+            {{ invoice.customer.name }}
+            <br />
+            {% if invoice.customer.contact_point %}
+              Contact: {{ invoice.customer.contact_point }}
+              <br />
+            {% endif %}
+            {{ invoice.customer.address }}
+            <br />
+            {% if invoice.customer.address_2 %}
+              {{ invoice.customer.address_2 }}
+              <br />
+            {% endif %}
+            {{ invoice.customer.postcode }} {{ invoice.customer.city }}
+            <br />
+            {{ invoice.customer.country.name }}
+            <br />
+            {% if invoice.customer.vat %}
+              VAT ID: {{ invoice.customer.vat }}
+              <br />
+            {% endif %}
+            {% if invoice.customer.tax %}
+              Reg: {{ invoice.customer.tax }}
+              <br />
+            {% endif %}
+          </address>
+
+          <address id="from">
+            <h2>Issued by</h2>
+            {{ company_name }}
+            <br />
+            {{ company_address }}
+            <br />
+            {{ company_zip }} {{ company_city }}
+            <br />
+            {{ company_country }}
+            <br />
+            VAT ID: {{ company_vat_id }}
+          </address>
+        </div>
+
+        {% if invoice.customer_reference %}
+          <p>Customer reference: {{ invoice.customer_reference }}</p>
+        {% endif %}
+        {% if invoice.customer_note %}
+          <div class="customer_note">{{ invoice.customer_note|linebreaks }}</div>
+        {% endif %}
+
+        <table id="items">
+          <thead>
+            <tr>
+              <th>Description</th>
+              <th>Quantity</th>
+              <th>Rate</th>
+              <th>Subtotal</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in invoice.all_items %}
+              <tr>
+                <td>
+                  {{ item.description }}
+                  {% if item.has_date_range %}<em class="period">{{ item.get_date_range_display }}</em>{% endif %}
+                </td>
+                <td>{{ item.display_quantity }}</td>
+                <td>{{ item.display_price }}</td>
+                <td>{{ item.display_total_price }}</td>
+              </tr>
+            {% endfor %}
+            {% if invoice.discount %}
+              <tr>
+                <td>{{ invoice.discount.description }}</td>
+                <td></td>
+                <td>{{ invoice.discount.display_percents }}</td>
+                <td>{{ invoice.display_total_discount }}</td>
+              </tr>
+            {% endif %}
+          </tbody>
+          <tfoot>
+            {% if invoice.vat_rate and invoice.is_final %}
+              <tr>
+                <td>Exchange rate for VAT</td>
+                <td></td>
+                <td>{{ invoice.exchange_rate_czk }} Kč</td>
+                <td></td>
+              </tr>
+              <tr>
+                <td>Total excluding VAT</td>
+                <td></td>
+                <td>{{ invoice.total_amount_no_vat_czk }} Kč</td>
+                <td>{{ invoice.display_total_amount_no_vat }}</td>
+              </tr>
+              <tr>
+                <td>VAT {{ invoice.vat_rate }}%</td>
+                <td></td>
+                <td>{{ invoice.total_vat_czk }} Kč</td>
+                <td>{{ invoice.display_total_vat }}</td>
+              </tr>
+              <tr class="subtotal">
+                <td>Total including VAT</td>
+                <td></td>
+                <td>{{ invoice.total_amount_czk }} Kč</td>
+                <td>{{ invoice.display_total_amount }}</td>
+              </tr>
+            {% else %}
+              <tr>
+                <td>
+                  VAT {{ invoice.vat_rate }}%
+                  {% if not invoice.vat_rate %}
+                    –
+                    {% if invoice.customer.is_eu %}
+                      Reverse charge
+                    {% else %}
+                      Place of supply outside EU
+                    {% endif %}
+                  {% endif %}
+                </td>
+                <td></td>
+                <td></td>
+                <td>{{ invoice.display_total_vat }}</td>
+              </tr>
+              <tr>
+                <td>Grand total</td>
+                <td></td>
+                <td></td>
+                <td>{{ invoice.display_total_amount }}</td>
+              </tr>
+            {% endif %}
+          </tfoot>
+        </table>
+      </main>
+
+      <footer>
+        <table id="total" class="fullwidth">
+          <thead>
+            <tr>
+              <th>
+                {% if invoice.is_draft %}
+                  Quote amount
+                {% elif is_receipt %}
+                  Amount
+                {% else %}
+                  Total due
+                {% endif %}
+              </th>
+              <th>
+                {% if is_receipt %}
+                  Paid on
+                {% elif invoice.is_draft %}
+                  Valid until
+                {% else %}
+                  Due by
+                {% endif %}
+              </th>
+              <th>Payment</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <strong>{{ invoice.display_total_amount }}</strong>
+              </td>
+              <td>
+                {% if is_receipt %}
+                  {{ invoice.get_payment.created|date }}
+                {% else %}
+                  {{ invoice.due_date|date }}
+                {% endif %}
+              </td>
+              <td>
+                {% if invoice.is_draft %}
+                  Bank transfer or card payments are available
+                {% elif invoice.prepaid or is_receipt %}
+                  {% if not is_receipt %}Do not pay, already paid{% endif %}
+                  <div class="method">
+                    {% for payment in invoice.paid_payment_set.all %}
+                      {{ payment.get_payment_description }}
+                      <div class="uuid">{{ payment.pk }}</div>
+                    {% endfor %}
+                  </div>
+                {% else %}
+                  Bank transfer
                   <br />
-                {% endfor %}
-                Reference: {{ invoice.number }}
-                <br />
-              {% endif %}
-            </td>
-            <td>{{ invoice.get_payment_qrcode }}</td>
-          </tr>
-        </tbody>
-      </table>
-      {% with payment_url=invoice.get_payment_url %}
-        {% if payment_url %}
-          <p>
-            Prefer card payment? <a href="{{ payment_url }}">{{ payment_url }}</a>
-          </p>
-        {% endif %}
-      {% endwith %}
-      <p>
-        {% if is_receipt %}
-          {% with payment=invoice.get_payment %}
-            {% if payment.backend == "fio-bank" %}
-              We confirm that the bank transfer payment of the invoice {{ invoice.number }} was received on {{ payment.created|date }}.
-            {% else %}
-              We confirm that the payment of the invoice {{ invoice.number }} was received on {{ payment.created|date }}.
-            {% endif %}
-          {% endwith %}
-        {% else %}
-          {% if invoice.is_draft %}
-            Should you have any questions concerning this quotation, please contact us at <a href="{{ company_sales_email_mailto }}">{{ company_sales_email }}</a>.
+                  {% for item, value in invoice.bank_account.get_short_info %}
+                    {{ item }}: {{ value }}
+                    <br />
+                  {% endfor %}
+                  Reference: {{ invoice.number }}
+                  <br />
+                {% endif %}
+              </td>
+              <td>{{ invoice.get_payment_qrcode }}</td>
+            </tr>
+          </tbody>
+        </table>
+        {% with payment_url=invoice.get_payment_url %}
+          {% if payment_url %}
+            <p>
+              Prefer card payment? <a href="{{ payment_url }}">{{ payment_url }}</a>
+            </p>
           {% endif %}
-          {% if invoice.vat_rate == 0 %}
-            {% if invoice.customer.is_eu %}
-
-              VAT exempt under reverse charge mechanism pursuant to Article 196 of Directive 2006/112/EC.
-
-              Reverse charge applies.
-
-              VAT to be accounted for by the recipient in accordance with the EU VAT rules.
-            {% else %}
-              VAT not applicable because the place of supply is outside the EU.
-
-            {% endif %}
-          {% endif %}
-          {% if invoice.is_final %}
-            This is a computer-generated invoice; signature not required.
-          {% elif invoice.is_proforma %}
-            This is not a tax document.
-          {% endif %}
-        {% endif %}
-      </p>
-      <table id="details">
-        <tbody>
-          <tr>
-            <th>
-              {% if invoice.is_draft %}
-                Quote date
-              {% elif invoice.is_proforma %}
-                Issue date
+        {% endwith %}
+        <p>
+          {% if is_receipt %}
+            {% with payment=invoice.get_payment %}
+              {% if payment.backend == "fio-bank" %}
+                We confirm that the bank transfer payment of the invoice {{ invoice.number }} was received on {{ payment.created|date }}.
               {% else %}
-                Date of taxable supply
+                We confirm that the payment of the invoice {{ invoice.number }} was received on {{ payment.created|date }}.
               {% endif %}
-            </th>
-            <th>CIN (IČ)</th>
-            <th>Managing director</th>
-            <th>Trade register</th>
-            <th>Contact</th>
-          </tr>
-          <tr>
-            <td>{{ invoice.tax_date|date }}</td>
-            <td>{{ company_id }}</td>
-            <td>Michal Čihař</td>
-            <td>C 52324/KSUL Krajský soud v Ústí nad Labem</td>
-            <td>
-              <a href="{{ company_sales_email_mailto }}">{{ company_sales_email }}</a>
-            </td>
-          </tr>
-          <tr>
-            <th>Account holder</th>
-            <th>Account number</th>
-            <th>BIC</th>
-            <th>Issuing bank</th>
-            <th></th>
-          </tr>
-          <tr>
-            <td>{{ company_name }}</td>
-            <td>{{ invoice.bank_account.number }}</td>
-            <td>{{ invoice.bank_account.bic }}</td>
-            <td>{{ invoice.bank_account.bank }}</td>
-            <td class="thanks">♥ Thank you!</td>
-          </tr>
-        </tbody>
-      </table>
-    </footer>
+            {% endwith %}
+          {% else %}
+            {% if invoice.is_draft %}
+              Should you have any questions concerning this quotation, please contact us at <a href="{{ company_sales_email_mailto }}">{{ company_sales_email }}</a>.
+            {% endif %}
+            {% if invoice.vat_rate == 0 %}
+              {% if invoice.customer.is_eu %}
+
+                VAT exempt under reverse charge mechanism pursuant to Article 196 of Directive 2006/112/EC.
+
+                Reverse charge applies.
+
+                VAT to be accounted for by the recipient in accordance with the EU VAT rules.
+              {% else %}
+                VAT not applicable because the place of supply is outside the EU.
+
+              {% endif %}
+            {% endif %}
+            {% if invoice.is_final %}
+              This is a computer-generated invoice; signature not required.
+            {% elif invoice.is_proforma %}
+              This is not a tax document.
+            {% endif %}
+          {% endif %}
+        </p>
+        <table id="details">
+          <tbody>
+            <tr>
+              <th>
+                {% if invoice.is_draft %}
+                  Quote date
+                {% elif invoice.is_proforma %}
+                  Issue date
+                {% else %}
+                  Date of taxable supply
+                {% endif %}
+              </th>
+              <th>CIN (IČ)</th>
+              <th>Managing director</th>
+              <th>Trade register</th>
+              <th>Contact</th>
+            </tr>
+            <tr>
+              <td>{{ invoice.tax_date|date }}</td>
+              <td>{{ company_id }}</td>
+              <td>Michal Čihař</td>
+              <td>C 52324/KSUL Krajský soud v Ústí nad Labem</td>
+              <td>
+                <a href="{{ company_sales_email_mailto }}">{{ company_sales_email }}</a>
+              </td>
+            </tr>
+            <tr>
+              <th>Account holder</th>
+              <th>Account number</th>
+              <th>BIC</th>
+              <th>Issuing bank</th>
+              <th></th>
+            </tr>
+            <tr>
+              <td>{{ company_name }}</td>
+              <td>{{ invoice.bank_account.number }}</td>
+              <td>{{ invoice.bank_account.bic }}</td>
+              <td>{{ invoice.bank_account.bank }}</td>
+              <td class="thanks">♥ Thank you!</td>
+            </tr>
+          </tbody>
+        </table>
+      </footer>
+    </div>
   </body>
 </html>

--- a/weblate_web/invoices/templates/invoice.css
+++ b/weblate_web/invoices/templates/invoice.css
@@ -2,6 +2,21 @@
   margin: 1cm;
 }
 
+@page invoice-with-page-marker {
+  margin: 1cm;
+
+  @bottom-center {
+    color: #a9a;
+    /* biome-ignore lint/correctness/noUnknownFunction: WeasyPrint paged media supports CSS strings. */
+    content: string(document-title) " · Page " counter(page) " of "
+      counter(pages);
+    font-family:
+      Source Sans Pro,
+      sans-serif;
+    font-size: 8pt;
+  }
+}
+
 html,
 a {
   color: #14213d;
@@ -22,6 +37,20 @@ body {
   margin: 0;
   padding: 0;
 }
+.invoice-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 277mm;
+}
+.invoice-page.with-page-marker {
+  page: invoice-with-page-marker;
+}
+.invoice-page > * {
+  flex-shrink: 0;
+}
+main {
+  flex-grow: 1;
+}
 header {
   display: block;
   padding-bottom: 1.3cm;
@@ -30,6 +59,8 @@ header {
 h1 {
   font-size: 12pt;
   padding-top: 3mm;
+  /* biome-ignore lint/correctness/noUnknownFunction: WeasyPrint paged media supports CSS strings. */
+  string-set: document-title content(text);
 }
 header p,
 header h1 {
@@ -111,9 +142,8 @@ address {
   margin-top: 1cm;
 }
 footer {
+  break-inside: avoid;
   display: block;
-  bottom: 0;
-  position: absolute;
 }
 #details td,
 #details th,

--- a/weblate_web/invoices/tests.py
+++ b/weblate_web/invoices/tests.py
@@ -5,6 +5,7 @@ from datetime import date, timedelta
 from decimal import Decimal
 from pathlib import Path
 from typing import cast
+from unittest.mock import patch
 
 import requests
 import responses
@@ -318,6 +319,27 @@ class InvoiceTestCase(UserTestCase):
         html = invoice.render_html()
 
         self.assertIn("Contact: Finance approvals", html)
+
+    def test_pdf_page_marker_is_added_only_for_multi_page_invoice(self) -> None:
+        invoice = self.create_invoice(kind=InvoiceKind.QUOTE)
+
+        with (
+            patch(
+                "weblate_web.invoices.models.count_pdf_pages",
+                side_effect=[1, 2],
+            ) as count_pdf_pages,
+            patch("weblate_web.invoices.models.render_pdf") as render_pdf,
+        ):
+            invoice.generate_pdf()
+            single_page_html = render_pdf.call_args.kwargs["html"]
+
+            render_pdf.reset_mock()
+            invoice.generate_pdf()
+            multi_page_html = render_pdf.call_args.kwargs["html"]
+
+        self.assertEqual(count_pdf_pages.call_count, 2)
+        self.assertNotIn("with-page-marker", single_page_html)
+        self.assertIn("with-page-marker", multi_page_html)
 
     def mock_requests(self) -> None:
         mock_vies()

--- a/weblate_web/pdf.py
+++ b/weblate_web/pdf.py
@@ -28,7 +28,7 @@ from weasyprint.text.fonts import FontConfiguration
 from weasyprint.urls import FatalURLFetchingError, URLFetcher, URLFetcherResponse
 
 if TYPE_CHECKING:
-    from weasyprint import Attachment
+    from weasyprint import Attachment, Document
 
 SIGNATURE_URL = "signature:"
 INVOICES_URL = "invoices:"
@@ -121,13 +121,7 @@ class WeblateUrlFetcher(URLFetcher):
         return URLFetcherResponse(url, path_obj.read_bytes(), response_headers)
 
 
-def render_pdf(
-    *,
-    html: str,
-    output: Path,
-    attachments: list[Attachment] | None = None,
-    factur_x: bool = False,
-) -> None:
+def render_pdf_document(*, html: str) -> Document:
     font_config = FontConfiguration()
     fetcher = WeblateUrlFetcher()
 
@@ -143,10 +137,24 @@ def render_pdf(
         font_config=font_config,
         url_fetcher=fetcher,
     )
-    document = renderer.render(
+    return renderer.render(
         stylesheets=[font_style],
         font_config=font_config,
     )
+
+
+def count_pdf_pages(*, html: str) -> int:
+    return len(render_pdf_document(html=html).pages)
+
+
+def render_pdf(
+    *,
+    html: str,
+    output: Path,
+    attachments: list[Attachment] | None = None,
+    factur_x: bool = False,
+) -> None:
+    document = render_pdf_document(html=html)
     if factur_x:
         document.metadata.xmp_metadata = [FACTURX_RDF_METADATA.encode("utf-8")]
     if attachments:

--- a/weblate_web/tests_e2e/test_invoice_screenshots.py
+++ b/weblate_web/tests_e2e/test_invoice_screenshots.py
@@ -27,9 +27,11 @@ from datetime import date
 from decimal import Decimal
 from pathlib import Path
 from shutil import which
+from typing import cast
 from uuid import UUID
 
 import pytest
+from PIL import Image as PILImage
 
 from weblate_web.invoices.models import (
     Currency,
@@ -49,6 +51,10 @@ pytestmark = [
 SCREENSHOT_DIR = Path("test-results")
 ISSUE_DATE = date(2026, 1, 15)
 DUE_DATE = date(2026, 1, 29)
+MAX_LOGO_RED = 90
+MIN_LOGO_GREEN = 120
+MIN_LOGO_BLUE = 90
+MIN_LOGO_MARK_PIXELS = 500
 
 
 @dataclass(frozen=True)
@@ -152,8 +158,8 @@ def create_invoice(case: InvoiceData, sequence: int) -> Invoice:
 
 def convert_pdf_to_screenshots(pdf_path: Path, screenshot_name: str) -> list[Path]:
     """Rasterize all PDF pages into Argos-consumed PNG screenshots."""
-    converter = which("pdftoppm")
-    assert converter is not None, "pdftoppm is required for invoice PDF screenshots"
+    converter = which("gs")
+    assert converter is not None, "Ghostscript is required for invoice PDF screenshots"
 
     SCREENSHOT_DIR.mkdir(exist_ok=True)
     for screenshot in SCREENSHOT_DIR.glob(f"{screenshot_name}-*.png"):
@@ -163,11 +169,15 @@ def convert_pdf_to_screenshots(pdf_path: Path, screenshot_name: str) -> list[Pat
     subprocess.run(
         [
             converter,
-            "-png",
-            "-r",
-            "144",
+            "-dSAFER",
+            "-dBATCH",
+            "-dNOPAUSE",
+            "-sDEVICE=png16m",
+            "-r144",
+            "-dTextAlphaBits=4",
+            "-dGraphicsAlphaBits=4",
+            f"-sOutputFile={output_prefix.as_posix()}-%d.png",
             pdf_path.as_posix(),
-            output_prefix.as_posix(),
         ],
         check=True,
     )
@@ -176,7 +186,29 @@ def convert_pdf_to_screenshots(pdf_path: Path, screenshot_name: str) -> list[Pat
     assert screenshots, f"No screenshots generated for {pdf_path}"
     for screenshot in screenshots:
         assert screenshot.stat().st_size > 0
+    assert_invoice_logo_rendered(screenshots[0])
     return screenshots
+
+
+def assert_invoice_logo_rendered(screenshot: Path) -> None:
+    """Verify the colored Weblate mark is present, not only the wordmark."""
+    with PILImage.open(screenshot) as image:
+        header = image.crop((0, 0, min(image.width, 600), min(image.height, 240)))
+        header = header.convert("RGB")
+        logo_pixels = 0
+        for y in range(header.height):
+            for x in range(header.width):
+                pixel = cast("tuple[int, int, int]", header.getpixel((x, y)))
+                if is_logo_mark_pixel(pixel):
+                    logo_pixels += 1
+    assert logo_pixels > MIN_LOGO_MARK_PIXELS, (
+        f"Invoice logo mark is missing from {screenshot}"
+    )
+
+
+def is_logo_mark_pixel(pixel: tuple[int, int, int]) -> bool:
+    red, green, blue = pixel
+    return red < MAX_LOGO_RED and green > MIN_LOGO_GREEN and blue > MIN_LOGO_BLUE
 
 
 def test_invoice_pdf_screenshots(settings, tmp_path):


### PR DESCRIPTION
Prevent long invoice content from rendering under the footer, mark multi-page PDFs, and use Ghostscript for e2e screenshots so the original logo rasterizes correctly.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
