### PR TITLE
fix(crm): stabilize customer detail ordering

### DIFF
--- a/weblate_web/crm/models.py
+++ b/weblate_web/crm/models.py
@@ -28,6 +28,11 @@ class InteractionDetailRow:
     url: str = ""
 
 
+class InteractionQuerySet(models.QuerySet["Interaction", "Interaction"]):
+    def order(self) -> InteractionQuerySet:
+        return self.order_by("-timestamp", "origin", "summary", "pk")
+
+
 class Interaction(models.Model):
     class Origin(models.IntegerChoices):
         EMAIL = 1, "Outbound e-mail"
@@ -53,6 +58,8 @@ class Interaction(models.Model):
         help_text="For example Zammad attachment ID",
         default=0,
     )
+
+    objects = InteractionQuerySet.as_manager()
 
     class Meta:
         ordering = ["-timestamp"]

--- a/weblate_web/crm/templates/payments/customer_detail.html
+++ b/weblate_web/crm/templates/payments/customer_detail.html
@@ -81,7 +81,7 @@
     {% endif %}
     <h2>Agreements</h2>
     <table>
-      {% for agreement in object.agreement_set.all %}
+      {% for agreement in object.agreement_set.order %}
         <tr>
           <td>{{ agreement.signed }}</td>
           <td>{{ agreement.get_kind_display }}</td>
@@ -110,7 +110,7 @@
     </table>
     <h2>Invoices</h2>
     <table>
-      {% include "invoices/invoice_list_content.html" with object_list=object.invoice_set.all %}
+      {% include "invoices/invoice_list_content.html" with object_list=object.invoice_set.order %}
     </table>
     {% if perms.invoices.add_invoice %}
       <a href="{% url "admin:invoices_invoice_add" %}?customer={{ object.pk }}"
@@ -123,7 +123,7 @@
       <input type="submit" name="add_manual_note" value="{% translate "Add note" %}">
     </form>
     <table>
-      {% for interaction in object.interaction_set.all %}
+      {% for interaction in object.interaction_set.order %}
         <tr>
           <td>{{ interaction.timestamp }}</td>
           <td>{{ interaction.user.username }}</td>
@@ -145,7 +145,7 @@
     </table>
     <h2>Payments</h2>
     <table>
-      {% for payment in object.payment_set.all %}
+      {% for payment in object.payment_set.order %}
         <tr>
           <td>{{ payment.created }}</td>
           <td>{{ payment.get_state_display }}</td>

--- a/weblate_web/crm/tests.py
+++ b/weblate_web/crm/tests.py
@@ -298,6 +298,61 @@ class CRMTestCase(BaseCRMTestCase):
         self.assertContains(response, 'name="note"')
         self.assertContains(response, "Add note")
 
+    def test_customer_detail_uses_stable_related_ordering(self):
+        customer = self.create_customer()
+        customer.email = "billing@example.com"
+        customer.save(update_fields=["email"])
+        user_b = User.objects.create_user(username="user-b", email="b@example.com")
+        user_a = User.objects.create_user(username="user-a", email="a@example.com")
+        customer.users.add(user_b, user_a)
+
+        timestamp = timezone.now()
+        beta_interaction = customer.interaction_set.create(
+            origin=Interaction.Origin.MANUAL_NOTE,
+            summary="Beta note",
+            content="Beta note",
+            timestamp=timestamp,
+            user=self.user,
+        )
+        alpha_interaction = customer.interaction_set.create(
+            origin=Interaction.Origin.MANUAL_NOTE,
+            summary="Alpha note",
+            content="Alpha note",
+            timestamp=timestamp,
+            user=self.user,
+        )
+        beta_payment = Payment.objects.create(
+            customer=customer, amount=1, description="Beta payment"
+        )
+        alpha_payment = Payment.objects.create(
+            customer=customer, amount=1, description="Alpha payment"
+        )
+        Payment.objects.filter(pk__in=(beta_payment.pk, alpha_payment.pk)).update(
+            created=timestamp
+        )
+
+        response = self.client.get(customer.get_absolute_url())
+
+        self.assertEqual(
+            customer.get_notify_emails(),
+            ["a@example.com", "b@example.com", "billing@example.com"],
+        )
+        self.assertEqual(
+            [user.email for user in response.context["customer_users"]],
+            ["a@example.com", "b@example.com"],
+        )
+        self.assertEqual(
+            list(customer.interaction_set.order()),
+            [alpha_interaction, beta_interaction],
+        )
+        self.assertEqual(
+            list(customer.payment_set.order()),
+            [alpha_payment, beta_payment],
+        )
+        content = response.content.decode()
+        self.assertLess(content.index("Alpha note"), content.index("Beta note"))
+        self.assertLess(content.index("Alpha payment"), content.index("Beta payment"))
+
     def test_customer_detail_hides_add_customer_user_for_readonly_staff(self):
         customer = self.create_customer()
         readonly_user = User.objects.create_user(

--- a/weblate_web/crm/views.py
+++ b/weblate_web/crm/views.py
@@ -530,7 +530,7 @@ class CustomerListView(CRMMixin, ListView[Customer]):  # type: ignore[misc]
         return context
 
     def get_queryset(self) -> CustomerQuerySet:
-        qs = cast("CustomerQuerySet", super().get_queryset().order_by("name", "email"))
+        qs = cast("CustomerQuerySet", super().get_queryset()).order()
         if query := self.request.GET.get("q"):
             qs = qs.filter(
                 Q(name__icontains=query)
@@ -576,8 +576,9 @@ class CustomerDetailView(CRMMixin, DetailView[Customer]):  # type: ignore[misc]
         context["can_add_customer_user"] = self.request.user.has_perm(
             self.add_customer_user_permission
         )
-        context["services"] = self.object.service_set.customer_services()
-        context["donations"] = self.object.service_set.donations()
+        context["services"] = self.object.service_set.customer_services().order()
+        context["donations"] = self.object.service_set.donations().order()
+        context["customer_users"] = self.object.ordered_users
         return context
 
     @classmethod

--- a/weblate_web/invoices/models.py
+++ b/weblate_web/invoices/models.py
@@ -296,6 +296,11 @@ class Discount(models.Model):
         return f"{self.percents}%"
 
 
+class InvoiceQuerySet(models.QuerySet["Invoice", "Invoice"]):
+    def order(self) -> InvoiceQuerySet:
+        return self.order_by("-issue_date", "-number")
+
+
 class Invoice(models.Model):  # noqa: PLR0904
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     sequence = models.IntegerField(editable=False)
@@ -369,6 +374,8 @@ class Invoice(models.Model):  # noqa: PLR0904
 
     # Manual disabling of XML in invoices
     generate_en_16931 = True
+
+    objects = InvoiceQuerySet.as_manager()
 
     class Meta:
         constraints = [

--- a/weblate_web/legal/models.py
+++ b/weblate_web/legal/models.py
@@ -45,9 +45,9 @@ class AgreementKind(models.IntegerChoices):
     DPA = 1, "Data Processing Agreement"
 
 
-class AgreementQuerySet(models.QuerySet):
-    def order(self):
-        return self.order_by("signed", "kind")
+class AgreementQuerySet(models.QuerySet["Agreement", "Agreement"]):
+    def order(self) -> AgreementQuerySet:
+        return self.order_by("signed", "kind", "pk")
 
 
 class Agreement(models.Model):

--- a/weblate_web/models.py
+++ b/weblate_web/models.py
@@ -703,7 +703,10 @@ class Package(models.Model):
         return get_donation_package_verbose(self.donation_reward)
 
 
-class ServiceQuerySet(models.QuerySet["Service"]):
+class ServiceQuerySet(models.QuerySet["Service", "Service"]):
+    def order(self) -> ServiceQuerySet:
+        return self.order_by("site_title", "site_url", "pk")
+
     def customer_services(self) -> ServiceQuerySet:
         return self.filter(kind=ServiceKind.SERVICE)
 

--- a/weblate_web/payments/models.py
+++ b/weblate_web/payments/models.py
@@ -102,7 +102,10 @@ VAT_RATE = 21
 DELETED_MAIL = re.compile(r"noreply\+[0-9]+@weblate.org")
 
 
-class CustomerQuerySet(models.QuerySet["Customer"]):
+class CustomerQuerySet(models.QuerySet["Customer", "Customer"]):
+    def order(self) -> CustomerQuerySet:
+        return self.order_by("name", "email", "pk")
+
     def for_user(self, user: User) -> CustomerQuerySet:
         return self.filter(users=user).distinct()
 
@@ -421,7 +424,14 @@ class Customer(models.Model):
 
     def get_notify_emails(self) -> list[str]:
         mails = {self.email, *self.users.values_list("email", flat=True)}
-        return [mail for mail in mails if mail and not DELETED_MAIL.match(mail)]
+        return sorted(
+            (mail for mail in mails if mail and not DELETED_MAIL.match(mail)),
+            key=str.casefold,
+        )
+
+    @property
+    def ordered_users(self) -> models.QuerySet[User, User]:
+        return self.users.order_by("email", "username", "pk")
 
     def get_upcoming_payment_invoices(self) -> models.QuerySet[Invoice]:
         from weblate_web.invoices.models import InvoiceKind  # noqa: PLC0415
@@ -607,6 +617,11 @@ RECURRENCE_CHOICES = [
 ]
 
 
+class PaymentQuerySet(models.QuerySet["Payment", "Payment"]):
+    def order(self) -> PaymentQuerySet:
+        return self.order_by("-created", "description", "uuid")
+
+
 class Payment(models.Model):
     NEW = 1
     PENDING = 2
@@ -676,6 +691,8 @@ class Payment(models.Model):
     start = models.DateField(blank=True, null=True)
     end = models.DateField(blank=True, null=True)
     card_info = models.JSONField(default=dict, blank=True)
+
+    objects = PaymentQuerySet.as_manager()
 
     class Meta:
         ordering = ["-created"]

--- a/weblate_web/templates/snippets/customer-users.html
+++ b/weblate_web/templates/snippets/customer-users.html
@@ -2,7 +2,7 @@
 
 <div class="line-left">{% translate "Users" %}</div>
 <div class="line-right">
-  {% for owner in customer.users.all %}
+  {% for owner in customer_users|default:customer.ordered_users %}
     <form id="server_user_{{ owner.id }}_form"
           method="post"
           action="{% url 'customer-user' pk=customer.pk %}">

--- a/weblate_web/tests_e2e/test_crm.py
+++ b/weblate_web/tests_e2e/test_crm.py
@@ -22,6 +22,7 @@
 from __future__ import annotations
 
 import re
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
@@ -123,13 +124,16 @@ def create_customer(
 
 def create_payment(customer: Customer, package: Package) -> Payment:
     """Create a processed payment suitable for a subscription."""
-    return Payment.objects.create(
+    payment = Payment.objects.create(
         amount=package.price,
         customer=customer,
         description=package.verbose,
         recurring=package.get_repeat(),
         state=Payment.PROCESSED,
     )
+    Payment.objects.filter(pk=payment.pk).update(created=FIXED_TIMESTAMP)
+    payment.created = FIXED_TIMESTAMP
+    return payment
 
 
 def create_service(customer: Customer, data: ServiceFixture) -> Service:
@@ -166,6 +170,18 @@ def create_invoice(customer: Customer, data: InvoiceFixture) -> Invoice:
     )
     invoice.invoiceitem_set.create(description=data.description, unit_price=data.amount)
     return invoice
+
+
+@contextmanager
+def fixed_interaction_timestamp(timestamp: datetime) -> Iterator[None]:
+    """Pin action-created interaction timestamps before visual captures."""
+    field = Interaction._meta.get_field("timestamp")  # pylint: disable=protected-access
+    original_default = field.default
+    field.default = lambda: timestamp
+    try:
+        yield
+    finally:
+        field.default = original_default
 
 
 @pytest.fixture
@@ -456,8 +472,9 @@ class TestCrmVisualCoverage:  # pylint: disable=redefined-outer-name
         capture(page, "customer-detail")
 
         page.fill('textarea[name="note"]', "Manual CRM note\nFollow-up requested.")
-        page.click('input[name="add_manual_note"]')
-        page.wait_for_load_state("networkidle")
+        with fixed_interaction_timestamp(FIXED_TIMESTAMP + timedelta(minutes=10)):
+            page.click('input[name="add_manual_note"]')
+            page.wait_for_load_state("networkidle")
         assert_no_server_error(page)
         assert_text_visible(page, "Manual CRM note", exact=False)
         capture(page, "customer-manual-note")
@@ -471,9 +488,12 @@ class TestCrmVisualCoverage:  # pylint: disable=redefined-outer-name
                 "last_name": "Linked User",
             },
         }
-        with patch(
-            "weblate_web.crm.views.ensure_hosted_user",
-            return_value=(hosted_payload, True),
+        with (
+            fixed_interaction_timestamp(FIXED_TIMESTAMP + timedelta(minutes=20)),
+            patch(
+                "weblate_web.crm.views.ensure_hosted_user",
+                return_value=(hosted_payload, True),
+            ),
         ):
             page.fill('input[name="email"]', "crm-linked@example.test")
             page.fill('input[name="full_name"]', "CRM Linked User")


### PR DESCRIPTION
Add reusable queryset ordering for timestamped CRM data so the customer add-user screenshot stays deterministic.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
