### PR TITLE
feat(crm): replace admin-styled CRM UI

### DIFF
--- a/weblate_web/crm/static/crm.css
+++ b/weblate_web/crm/static/crm.css
@@ -1,15 +1,1146 @@
+:root {
+  --crm-bg: #f4f7f8;
+  --crm-surface: #fff;
+  --crm-surface-muted: #eef5f3;
+  --crm-border: #d8e2e0;
+  --crm-border-strong: #b9c9c6;
+  --crm-text: #253342;
+  --crm-muted: #667783;
+  --crm-green: #1fa385;
+  --crm-green-dark: #144d3f;
+  --crm-green-soft: #dff5ef;
+  --crm-blue: #266c9f;
+  --crm-yellow: #9a6700;
+  --crm-yellow-soft: #fff4ce;
+  --crm-red: #b3261e;
+  --crm-red-soft: #fde7e5;
+  --crm-shadow: 0 8px 24px rgba(20, 77, 63, 0.08);
+}
+
+.crm-body {
+  background: var(--crm-bg);
+  color: var(--crm-text);
+  font-size: 15px;
+  line-height: 1.45;
+  min-width: 320px;
+  overflow-x: auto;
+  transition: none;
+}
+
+.crm-body a {
+  color: var(--crm-green-dark);
+  font-weight: 600;
+}
+
+.crm-body a:hover {
+  color: var(--crm-green);
+}
+
+.crm-body p {
+  margin: 0 0 0.75rem;
+}
+
+.crm-body code,
+.crm-preformatted {
+  font-family: "Source Code Pro", monospace;
+}
+
+.crm-body code {
+  font-size: 0.92em;
+}
+
+.crm-skip-link {
+  background: var(--crm-green-dark);
+  color: #fff;
+  left: 1rem;
+  padding: 0.5rem 0.75rem;
+  position: absolute;
+  top: -4rem;
+  z-index: 1000;
+}
+
+.crm-skip-link:focus {
+  top: 1rem;
+}
+
+.crm-sr-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.crm-body .crm-header {
+  background: var(--crm-green-dark);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
+  float: none;
+  left: auto;
+  padding: 0;
+  position: sticky;
+  top: 0;
+  width: 100%;
+  z-index: 100;
+}
+
+.crm-header__inner {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  margin: 0 auto;
+  max-width: 1500px;
+  min-height: 58px;
+  padding: 0 1.25rem;
+}
+
+.crm-body .crm-brand {
+  align-items: center;
+  color: #fff;
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 1.05rem;
+  font-weight: 700;
+  gap: 0.55rem;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
+.crm-body .crm-brand:hover {
+  color: #fff;
+  opacity: 0.86;
+}
+
+.crm-brand img {
+  height: 30px;
+  width: 30px;
+}
+
+.crm-menu-toggle {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.crm-menu-button {
+  display: none;
+}
+
+.crm-menu-panel {
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.crm-nav {
+  display: flex;
+  flex: 1 1 auto;
+  gap: 0.25rem;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.crm-nav a,
+.crm-user-actions a,
+.crm-user-actions button {
+  border-radius: 6px;
+  color: #eaf7f4;
+  display: inline-flex;
+  font-size: 0.92rem;
+  line-height: 1;
+  padding: 0.65rem 0.75rem;
+  white-space: nowrap;
+}
+
+.crm-nav a:hover,
+.crm-nav a.is-active,
+.crm-user-actions a:hover,
+.crm-user-actions button:hover {
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+}
+
+.crm-user-actions {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  gap: 0.25rem;
+}
+
+.crm-user-actions form {
+  margin: 0;
+}
+
+.crm-user-actions button {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+}
+
+.crm-main {
+  margin: 0 auto;
+  max-width: 1500px;
+  padding: 1rem 1.25rem 2rem;
+}
+
+.crm-breadcrumbs {
+  align-items: center;
+  color: var(--crm-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+  gap: 0.4rem;
+  margin: 0 0 0.75rem;
+}
+
+.crm-breadcrumbs a {
+  color: var(--crm-muted);
+}
+
+.crm-page-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  margin: 0 0 1rem;
+}
+
+.crm-page-header h1 {
+  color: var(--crm-text);
+  font-size: clamp(1.6rem, 2vw, 2.2rem);
+  line-height: 1.1;
+  margin: 0;
+}
+
+.crm-page-actions,
+.crm-toolbar__actions,
+.crm-row-actions,
+.crm-section-footer {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.crm-section-footer {
+  margin-top: 1rem;
+}
+
+.crm-body section,
+.crm-body section.content,
+.crm-section {
+  float: none;
+  padding: 0;
+  width: auto;
+}
+
+.crm-section {
+  background: var(--crm-surface);
+  border: 1px solid var(--crm-border);
+  border-radius: 8px;
+  box-shadow: var(--crm-shadow);
+  margin: 0 0 1rem;
+  overflow: hidden;
+  padding: 0;
+}
+
+.crm-section
+  > :not(.crm-section__header):not(.crm-table-wrap):not(.crm-panel-heading):not(
+    h2
+  ) {
+  margin: 1rem;
+}
+
+.crm-section__header,
+.crm-section > h2,
+.crm-panel-heading {
+  background: #fff;
+  border-radius: 7px 7px 0 0;
+  color: var(--crm-green-dark);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.25;
+  padding: 0.6rem 0.85rem;
+  text-align: start;
+}
+
+.crm-section__header,
+.crm-section > h2,
+.crm-panel-heading {
+  border-bottom: 1px solid var(--crm-border);
+  margin: 0;
+}
+
+.crm-section__header {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  left: auto;
+  position: static;
+  top: auto;
+  width: auto;
+  z-index: auto;
+}
+
+.crm-section__header > div {
+  min-width: 0;
+}
+
+.crm-section__header h2 {
+  color: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  margin: 0;
+}
+
+.crm-section__header p {
+  color: var(--crm-muted);
+  margin: 0.25rem 0 0;
+}
+
+.crm-section h3 {
+  color: var(--crm-text);
+  font-size: 1rem;
+  line-height: 1.25;
+  margin: 0 0 0.75rem;
+}
+
+.crm-section__actions {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.crm-dashboard-grid,
+.crm-report-grid,
+.crm-form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.crm-dashboard-grid {
+  grid-template-columns: repeat(auto-fit, minmax(310px, 1fr));
+}
+
+.crm-report-grid {
+  grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+}
+
+.crm-form-grid {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.crm-dashboard-section {
+  margin: 0;
+}
+
+.crm-dashboard-list {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.crm-dashboard-item {
+  background: var(--crm-surface-muted);
+  border: 1px solid transparent;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  position: relative;
+}
+
+.crm-dashboard-item:hover,
+.crm-dashboard-item:focus-within {
+  border-color: var(--crm-border-strong);
+}
+
+.crm-dashboard-link {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.crm-dashboard-link::after {
+  border-radius: 8px;
+  content: "";
+  inset: 0;
+  position: absolute;
+  z-index: 1;
+}
+
+.crm-dashboard-link:focus {
+  outline: 0;
+}
+
+.crm-dashboard-link:focus-visible::after {
+  box-shadow: 0 0 0 3px rgba(31, 163, 133, 0.28);
+}
+
+.crm-dashboard-link strong {
+  font-size: 1rem;
+}
+
+.crm-dashboard-link span {
+  color: var(--crm-muted);
+  font-weight: 400;
+}
+
+.crm-dashboard-item .crm-row-actions {
+  position: relative;
+  z-index: 2;
+}
+
+.crm-toolbar {
+  align-items: flex-end;
+  background: var(--crm-surface);
+  border: 1px solid var(--crm-border);
+  border-radius: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0 0 1rem;
+  padding: 0.75rem;
+}
+
+.crm-search {
+  margin: 0;
+}
+
+.crm-field {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.crm-field--fill {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.crm-field--fill textarea {
+  flex: 1 1 auto;
+}
+
+.crm-field--inline {
+  align-items: center;
+  display: flex;
+  flex: 1 1 320px;
+  gap: 0.5rem;
+}
+
+.crm-body label,
+.crm-field label,
+.crm-form-panel label {
+  color: var(--crm-text);
+  font-weight: 700;
+}
+
+.crm-body input[type="email"],
+.crm-body input[type="number"],
+.crm-body input[type="search"],
+.crm-body input[type="text"],
+.crm-body input[type="url"],
+.crm-body select,
+.crm-body textarea {
+  background: #fff;
+  border: 1px solid var(--crm-border-strong);
+  border-radius: 6px;
+  box-sizing: border-box;
+  color: var(--crm-text);
+  height: 2.35rem;
+  min-height: 2.35rem;
+  padding: 0.45rem 0.55rem;
+  width: 100%;
+}
+
+.crm-body textarea {
+  min-height: 7rem;
+  resize: vertical;
+}
+
+.crm-body input:focus,
+.crm-body select:focus,
+.crm-body textarea:focus {
+  border-color: var(--crm-green);
+  box-shadow: 0 0 0 3px rgba(31, 163, 133, 0.18);
+  outline: 0;
+}
+
+.crm-button,
+.crm-body input.crm-button,
+.crm-body button.crm-button,
+.crm-body a.crm-button {
+  align-items: center;
+  background: var(--crm-green);
+  border: 1px solid var(--crm-green);
+  border-radius: 6px;
+  color: #fff;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 0.92rem;
+  font-weight: 700;
+  justify-content: center;
+  line-height: 1.2;
+  min-height: 2.35rem;
+  min-width: 0;
+  padding: 0.5rem 0.8rem;
+  text-align: center;
+}
+
+.crm-button:hover,
+.crm-body input.crm-button:hover,
+.crm-body button.crm-button:hover,
+.crm-body a.crm-button:hover {
+  background: var(--crm-green-dark);
+  border-color: var(--crm-green-dark);
+  color: #fff;
+}
+
+.crm-button--secondary,
+.crm-body a.crm-button--secondary,
+.crm-body input.crm-button--secondary {
+  background: #fff;
+  border-color: var(--crm-border-strong);
+  color: var(--crm-green-dark);
+}
+
+.crm-button--secondary:hover,
+.crm-body a.crm-button--secondary:hover,
+.crm-body input.crm-button--secondary:hover {
+  background: var(--crm-green-soft);
+  border-color: var(--crm-green);
+  color: var(--crm-green-dark);
+}
+
+.crm-button--danger,
+.crm-body input.crm-button--danger {
+  background: var(--crm-red);
+  border-color: var(--crm-red);
+}
+
+.crm-button--danger:hover,
+.crm-body input.crm-button--danger:hover {
+  background: #7f1d1d;
+  border-color: #7f1d1d;
+}
+
+.crm-row-actions {
+  gap: 0.4rem;
+}
+
+.crm-row-actions a {
+  background: var(--crm-surface-muted);
+  border: 1px solid var(--crm-border);
+  border-radius: 5px;
+  display: inline-flex;
+  font-size: 0.86rem;
+  padding: 0.25rem 0.45rem;
+}
+
+.crm-row-actions a:hover {
+  background: var(--crm-green-soft);
+  border-color: var(--crm-green);
+}
+
+.crm-table-wrap {
+  background: var(--crm-surface);
+  box-sizing: border-box;
+  overflow-x: auto;
+  width: 100%;
+}
+
+.crm-section > .crm-table-wrap:first-child,
+.crm-section__header + .crm-table-wrap {
+  margin: 0;
+  width: 100%;
+}
+
+.crm-form-panel + .crm-table-wrap {
+  margin-top: 1rem;
+}
+
+.crm-table {
+  background: var(--crm-surface);
+  border-collapse: collapse;
+  min-width: 760px;
+  width: 100%;
+}
+
+.crm-table--summary {
+  min-width: 0;
+}
+
+.crm-table th,
+.crm-table td {
+  border-bottom: 1px solid var(--crm-border);
+  padding: 0.5rem 0.6rem;
+  text-align: start;
+  vertical-align: top;
+}
+
+.crm-table thead th {
+  background: var(--crm-surface-muted);
+  color: var(--crm-muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.crm-table tbody th {
+  font-weight: 700;
+}
+
+.crm-table tbody tr:hover {
+  background: #f8fbfa;
+}
+
+.crm-number {
+  text-align: end !important;
+  white-space: nowrap;
+}
+
+.crm-total-row th,
+.crm-total-row td {
+  background: var(--crm-surface-muted);
+  font-weight: 700;
+}
+
+.crm-detail-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin: 0;
+}
+
+.crm-detail-grid--compact {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.crm-detail-grid > div {
+  background: var(--crm-surface-muted);
+  border-radius: 8px;
+  padding: 0.65rem 0.75rem;
+}
+
+.crm-detail-grid > .crm-detail-grid__wide {
+  grid-column: span 2;
+}
+
+.crm-detail-grid dt {
+  color: var(--crm-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin: 0 0 0.2rem;
+  text-transform: uppercase;
+}
+
+.crm-detail-grid dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.crm-activation-key {
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+
+.crm-muted {
+  color: var(--crm-muted);
+  display: inline-block;
+}
+
+.crm-summary-line {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-bottom: 1rem;
+}
+
+.crm-summary-line span:not(.crm-badge),
+.crm-summary-line strong {
+  background: var(--crm-surface-muted);
+  border-radius: 5px;
+  padding: 0.2rem 0.45rem;
+}
+
+.crm-summary-line .crm-badge {
+  border-radius: 5px;
+  font-size: inherit;
+  line-height: inherit;
+  margin: 0;
+  padding: 0.2rem 0.45rem;
+}
+
+.crm-subscription-summary {
+  align-items: flex-start;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.crm-subscription-summary .crm-detail-grid {
+  margin: 0;
+}
+
+.crm-badge,
+.crm-token {
+  align-items: center;
+  background: var(--crm-green-soft);
+  border-radius: 999px;
+  color: var(--crm-green-dark);
+  display: inline-flex;
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1;
+  margin: 0 0.25rem 0.25rem 0;
+  padding: 0.2rem 0.5rem;
+  white-space: nowrap;
+}
+
+.crm-badge--success {
+  background: var(--crm-green-soft);
+  color: var(--crm-green-dark);
+}
+
+.crm-badge--warning {
+  background: var(--crm-yellow-soft);
+  color: var(--crm-yellow);
+}
+
+.crm-badge--danger {
+  background: var(--crm-red-soft);
+  color: var(--crm-red);
+}
+
+.crm-form-panel {
+  background: var(--crm-surface-muted);
+  border: 1px solid var(--crm-border);
+  border-radius: 8px;
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+  padding: 0.85rem;
+}
+
+.crm-form-panel--balanced {
+  grid-template-rows: auto minmax(0, 1fr) auto;
+}
+
+.crm-form-panel--danger {
+  background: var(--crm-red-soft);
+  border-color: rgba(179, 38, 30, 0.24);
+}
+
+.crm-form-panel h3 {
+  background: #fff;
+  border-bottom: 1px solid var(--crm-border);
+  border-radius: 7px 7px 0 0;
+  color: var(--crm-green-dark);
+  font-size: 1rem;
+  line-height: 1.25;
+  margin: -0.85rem -0.85rem 0;
+  padding: 0.6rem 0.85rem;
+}
+
+.crm-form-panel--danger h3 {
+  color: var(--crm-red);
+}
+
+.crm-form-panel--compact {
+  max-width: 720px;
+}
+
+.crm-form-panel--inline {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.crm-form-panel__body {
+  align-content: start;
+  display: grid;
+  gap: 0.65rem;
+  min-height: 0;
+}
+
+.crm-form-panel__actions {
+  align-self: end;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.crm-form-panel p,
+.crm-form-panel div {
+  margin: 0;
+}
+
+.crm-form-panel .helptext {
+  color: var(--crm-muted);
+  display: block;
+  font-size: 0.86rem;
+  margin-top: 0.2rem;
+}
+
+.crm-check {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.crm-check input {
+  flex: 0 0 auto;
+  margin-top: 0.2rem;
+}
+
+.crm-danger-action {
+  align-self: start;
+  background: var(--crm-red-soft);
+  border: 1px solid rgba(179, 38, 30, 0.24);
+  border-radius: 8px;
+  margin: 0;
+  padding: 0.85rem;
+}
+
+.crm-danger-action summary {
+  background: #fff;
+  border-bottom: 1px solid rgba(179, 38, 30, 0.24);
+  border-radius: 7px 7px 0 0;
+  color: var(--crm-red);
+  cursor: pointer;
+  font-weight: 800;
+  margin: -0.85rem -0.85rem 0;
+  padding: 0.6rem 0.85rem;
+}
+
+.crm-danger-action[open] summary {
+  margin-bottom: 0;
+}
+
+.crm-warning {
+  background: var(--crm-yellow-soft);
+  border: 1px solid rgba(154, 103, 0, 0.24);
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  padding: 0.85rem;
+}
+
+.crm-warning ul {
+  margin: 0.5rem 0 0 1.25rem;
+  padding: 0;
+}
+
+.crm-alert {
+  border-radius: 8px;
+  font-weight: 700;
+  margin: 0 0 0.75rem;
+  padding: 0.65rem 0.85rem;
+}
+
+.crm-alert.error {
+  background: var(--crm-red-soft);
+  color: var(--crm-red);
+}
+
+.crm-alert.success {
+  background: var(--crm-green-soft);
+  color: var(--crm-green-dark);
+}
+
+.crm-alert.warning {
+  background: var(--crm-yellow-soft);
+  color: var(--crm-yellow);
+}
+
+.crm-alert.info {
+  background: #e8f2fb;
+  color: var(--crm-blue);
+}
+
+.crm-empty {
+  background: var(--crm-surface-muted);
+  border: 1px dashed var(--crm-border-strong);
+  border-radius: 8px;
+  color: var(--crm-muted);
+  padding: 1rem;
+}
+
+.crm-empty p {
+  margin: 0;
+}
+
+.crm-pagination {
+  display: flex;
+  justify-content: center;
+  margin: 1rem 0 0;
+}
+
+.crm-pagination__links {
+  align-items: center;
+  background: var(--crm-surface);
+  border: 1px solid var(--crm-border);
+  border-radius: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding: 0.4rem;
+}
+
+.crm-pagination a,
+.crm-pagination span {
+  border-radius: 5px;
+  padding: 0.35rem 0.55rem;
+}
+
+.crm-pagination a {
+  background: var(--crm-surface-muted);
+}
+
+.crm-tab-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.crm-main > .crm-tab-list {
+  margin: 0 0 1rem;
+}
+
+.crm-tab-list a,
+.crm-tab-list span {
+  border: 1px solid var(--crm-border);
+  border-radius: 6px;
+  padding: 0.35rem 0.65rem;
+}
+
+.crm-tab-list .is-active {
+  background: var(--crm-green-dark);
+  border-color: var(--crm-green-dark);
+  color: #fff;
+  font-weight: 800;
+}
+
+.crm-metric {
+  color: var(--crm-green-dark);
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 800;
+  line-height: 1;
+  margin: 0.75rem 0 0;
+}
+
+.crm-chart {
+  overflow: hidden;
+  padding-top: 0.75rem;
+}
+
+.crm-chart svg {
+  display: block;
+  height: auto;
+  max-width: 100%;
+  width: 100%;
+}
+
+.crm-action-group {
+  border-top: 1px solid var(--crm-border);
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+}
+
+.crm-action-group > h3 {
+  color: var(--crm-green-dark);
+  font-size: 1rem;
+  line-height: 1.25;
+  margin: 0;
+}
+
+.crm-action-group > p {
+  color: var(--crm-muted);
+  margin: 0;
+}
+
+.crm-media {
+  border-top: 1px solid var(--crm-border);
+  margin-top: 1rem;
+  padding-top: 1rem;
+}
+
+.discover-img {
+  border-radius: 8px;
+  max-height: 260px;
+}
+
 .interaction-content {
-  border: 1px solid var(--border-color);
+  background: #fff;
+  border: 1px solid var(--crm-border-strong);
+  border-radius: 8px;
   min-height: 40em;
   width: 100%;
 }
 
-.crm-danger-action {
-  margin: 0.5em 0 1em;
+.crm-preformatted {
+  background: #17232f;
+  border-radius: 8px;
+  color: #eef5f3;
+  margin: 0;
+  max-height: 36rem;
+  overflow: auto;
+  padding: 1rem;
+  white-space: pre-wrap;
 }
 
-.crm-danger-action summary {
-  color: var(--error-fg);
-  cursor: pointer;
-  font-weight: 700;
+html[dir="rtl"] .crm-number {
+  text-align: start !important;
+}
+
+@media (max-width: 980px) {
+  .crm-header__inner {
+    align-items: center;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+  }
+
+  .crm-body .crm-menu-button {
+    align-items: center;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    border-radius: 6px;
+    color: #fff;
+    cursor: pointer;
+    display: inline-flex;
+    font-weight: 700;
+    justify-content: center;
+    min-height: 2.35rem;
+    padding: 0.5rem 0.8rem;
+  }
+
+  .crm-menu-button::before {
+    content: "";
+    display: inline-block;
+    height: 0.75rem;
+    margin-right: 0.5rem;
+    width: 1rem;
+    background:
+      linear-gradient(#fff, #fff) 0 0 / 100% 2px no-repeat,
+      linear-gradient(#fff, #fff) 0 50% / 100% 2px no-repeat,
+      linear-gradient(#fff, #fff) 0 100% / 100% 2px no-repeat;
+  }
+
+  html[dir="rtl"] .crm-menu-button::before {
+    margin-left: 0.5rem;
+    margin-right: 0;
+  }
+
+  .crm-menu-toggle:focus-visible + .crm-menu-button {
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.35);
+    outline: 0;
+  }
+
+  .crm-menu-panel {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 8px;
+    display: none;
+    grid-column: 1 / -1;
+    padding: 0.5rem;
+  }
+
+  .crm-menu-toggle:checked ~ .crm-menu-panel {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .crm-nav {
+    display: grid;
+    overflow-x: visible;
+    width: 100%;
+  }
+
+  .crm-user-actions {
+    display: grid;
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  .crm-nav a,
+  .crm-user-actions a,
+  .crm-user-actions button {
+    width: 100%;
+  }
+
+  .crm-page-header {
+    display: grid;
+  }
+
+  .crm-report-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .crm-main {
+    padding: 0.75rem 0.75rem 1.5rem;
+  }
+
+  .crm-section {
+    padding: 0;
+  }
+
+  .crm-section
+    > :not(.crm-section__header):not(.crm-table-wrap):not(
+      .crm-panel-heading
+    ):not(h2) {
+    margin: 0.8rem;
+  }
+
+  .crm-section > .crm-table-wrap:first-child,
+  .crm-section__header + .crm-table-wrap {
+    margin: 0;
+    width: 100%;
+  }
+
+  .crm-section__header,
+  .crm-toolbar,
+  .crm-field--inline {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .crm-dashboard-grid,
+  .crm-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .crm-subscription-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .crm-detail-grid > .crm-detail-grid__wide {
+    grid-column: auto;
+  }
+
+  .crm-form-panel--inline {
+    align-items: stretch;
+    flex-direction: column;
+  }
 }

--- a/weblate_web/crm/static/crm.js
+++ b/weblate_web/crm/static/crm.js
@@ -1,0 +1,24 @@
+const updateCrmMenuTabStop = () => {
+  const toggle = document.getElementById("crm-menu-toggle");
+  if (!toggle || !window.matchMedia) {
+    return;
+  }
+
+  const mobileNavigation = window.matchMedia("(max-width: 980px)");
+  const syncMenuTabStop = () => {
+    toggle.tabIndex = mobileNavigation.matches ? 0 : -1;
+  };
+
+  syncMenuTabStop();
+  if (mobileNavigation.addEventListener) {
+    mobileNavigation.addEventListener("change", syncMenuTabStop);
+  } else {
+    mobileNavigation.addListener(syncMenuTabStop);
+  }
+};
+
+if (document.readyState !== "loading") {
+  updateCrmMenuTabStop();
+} else {
+  document.addEventListener("DOMContentLoaded", updateCrmMenuTabStop);
+}

--- a/weblate_web/crm/templates/crm/base.html
+++ b/weblate_web/crm/templates/crm/base.html
@@ -1,35 +1,119 @@
-{% extends "admin/base.html" %}
+{% load i18n static %}
 
-{% load static %}
+<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}"
+      dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <meta name="description"
+          content="{% translate "Internal Weblate customer relationship management." %}">
+    <meta name="keywords" content="Weblate,CRM">
+    <title>
+      {% block title %}
+        {% if subtitle %}{{ subtitle }} |{% endif %}
+        {{ title }} | Weblate CRM
+      {% endblock title %}
 
-{% block extrastyle %}
-  {{ block.super }}
-  <link rel="stylesheet" href="{% static "crm.css" %}">
-{% endblock extrastyle %}
+    </title>
+    <link rel="icon" type="image/png" sizes="32x32" href="{% static "logo-32.png" %}">
+    <link rel="icon" type="image/png" sizes="16x16" href="{% static "logo-16.png" %}">
+    <link rel="stylesheet" href="{% static "style.css" %}">
+    <link rel="stylesheet" href="{% static "weblate_fonts/source-sans-3.css" %}">
+    <link rel="stylesheet" href="{% static "weblate_fonts/source-code-pro.css" %}">
+    <link rel="stylesheet" href="{% static "crm.css" %}">
+    <script src="{% static "crm.js" %}" defer></script>
+    {% block extrastyle %}
+    {% endblock extrastyle %}
 
-{% block title %}
-  {% if subtitle %}{{ subtitle }} |{% endif %}
-  {{ title }} | Weblate CRM
-{% endblock title %}
+  </head>
+  <body class="crm-body {% block bodyclass %}{% endblock %}
+     ">
+    <a class="crm-skip-link" href="#crm-content">{% translate "Skip to main content" %}</a>
+    <header class="crm-header">
+      <div class="crm-header__inner">
+        <a class="crm-brand" href="{% url "crm:index" %}">
+          <img src="{% static "weblate-tiny.svg" %}" alt="">
+          <span>Weblate CRM</span>
+        </a>
 
-{% block branding %}
-  <div id="site-name">
-    <a href="{% url 'crm:index' %}">Weblate CRM</a>
-  </div>
-  {% if user.is_anonymous %}
-    {% include "admin/color_theme_toggle.html" %}
-  {% endif %}
-{% endblock branding %}
+        <input id="crm-menu-toggle"
+               class="crm-menu-toggle"
+               type="checkbox"
+               tabindex="-1"
+               aria-label="{% translate "Toggle navigation" %}">
+        <label class="crm-menu-button" for="crm-menu-toggle">{% translate "Menu" %}</label>
 
-{% block nav-global %}{% endblock %}
+        <div class="crm-menu-panel" id="crm-menu">
+          <nav class="crm-nav" aria-label="{% translate "CRM navigation" %}">
+            <a href="{% url "crm:index" %}"
+               class="{% if request.resolver_match.url_name == "index" %}is-active{% endif %}">{% translate "Dashboard" %}</a>
+            {% if perms.payments.view_customer %}
+              <a href="{% url "crm:customer-list" kind="all" %}"
+                 aria-label="{% translate "Customer records" %}"
+                 class="{% if request.resolver_match.url_name == "customer-list" or request.resolver_match.url_name == "customer-detail" or request.resolver_match.url_name == "customer-merge" or request.resolver_match.url_name == "interaction-detail" %}is-active{% endif %}">{% translate "Customers" %}</a>
+            {% endif %}
+            {% if perms.weblate_web.view_service %}
+              <a href="{% url "crm:service-list" kind="all" %}"
+                 class="{% if request.resolver_match.url_name == "service-list" or request.resolver_match.url_name == "service-detail" %}is-active{% endif %}">{% translate "Services" %}</a>
+            {% endif %}
+            {% if perms.invoices.view_invoice %}
+              <a href="{% url "crm:invoice-list" kind="invoice" %}"
+                 class="{% if request.resolver_match.url_name == "invoice-list" or request.resolver_match.url_name == "invoice-detail" %}is-active{% endif %}">{% translate "Invoices" %}</a>
+            {% endif %}
+            {% if perms.invoices.view_income %}
+              <a href="{% url "crm:income" %}"
+                 class="{% if request.resolver_match.url_name == "income" or request.resolver_match.url_name == "income-year" or request.resolver_match.url_name == "income-month" %}is-active{% endif %}">{% translate "Income" %}</a>
+            {% endif %}
+          </nav>
 
-{% block breadcrumbs %}
-  <div class="breadcrumbs">
-    <a href="{% url 'crm:index' %}">CRM</a>
+          <div class="crm-user-actions">
+            <a href="{% url "home" %}">{% translate "Website" %}</a>
+            <a href="{% url "admin:index" %}">{% translate "Admin" %}</a>
+            {% if user.is_authenticated %}
+              <form action="{% url "logout" %}" method="post">
+                {% csrf_token %}
+                <button type="submit">{% translate "Sign out" %}</button>
+              </form>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </header>
 
-    {% block breadcrum_list %}
-    {% endblock breadcrum_list %}
+    <main id="crm-content" class="crm-main">
+      <nav class="crm-breadcrumbs" aria-label="{% translate "Breadcrumbs" %}">
+        <a href="{% url "crm:index" %}">{% translate "CRM" %}</a>
+        {% block breadcrum_list %}
+        {% endblock breadcrum_list %}
 
-    {% if title and title != "CRM" %}› {{ title }}{% endif %}
-  </div>
-{% endblock breadcrumbs %}
+        {% if title and title != "CRM" %}<span aria-hidden="true">›</span><span>{{ title }}</span>{% endif %}
+      </nav>
+
+      {% block page_header %}
+        <div class="crm-page-header">
+          <div>
+            <h1>{{ title|default:"CRM" }}</h1>
+          </div>
+          {% block page_actions %}
+          {% endblock page_actions %}
+
+        </div>
+      {% endblock page_header %}
+
+      {% if messages %}
+        <section class="crm-messages" aria-label="{% translate "Messages" %}">
+          {% for message in messages %}
+            <div class="crm-alert {{ message.tags }}" role="alert">{{ message }}</div>
+          {% endfor %}
+        </section>
+      {% endif %}
+
+      {% block content %}
+      {% endblock content %}
+
+    </main>
+  </body>
+</html>

--- a/weblate_web/crm/templates/crm/income.html
+++ b/weblate_web/crm/templates/crm/income.html
@@ -1,165 +1,168 @@
 {% extends "crm/base.html" %}
 
-{% load i18n static %}
+{% load i18n %}
 
-{% block bodyclass %}{{ block.super }} dashboard{% endblock %}
-
-{% block extrastyle %}
-  {{ block.super }}
-  <link rel="stylesheet" href="{% static "admin/css/dashboard.css" %}">
-{% endblock extrastyle %}
+{% block bodyclass %}dashboard{% endblock %}
 
 {% block content %}
-  <div id="content-main">
-    {% if is_monthly %}
-      <p>
-        <a href="{% url 'crm:income-year' current_year %}">← {% translate "Back to" %} {{ current_year }} {% translate "yearly view" %}</a>
-      </p>
-    {% endif %}
-
-    <div class="module">
-      <table>
-        <caption>{% translate "Year" %}</caption>
-        <tr>
-          {% for year in years %}
-            <td>
-              {% if year == current_year %}
-                <strong>{{ year }}</strong>
-              {% else %}
-                <a href="{% url 'crm:income-year' year %}">{{ year }}</a>
-              {% endif %}
-            </td>
-          {% endfor %}
-        </tr>
-      </table>
+  {% if is_monthly %}
+    <div class="crm-toolbar">
+      <a class="crm-button crm-button--secondary"
+         href="{% url "crm:income-year" current_year %}">
+        {% blocktranslate %}Back to {{ current_year }} yearly view{% endblocktranslate %}
+      </a>
     </div>
+  {% endif %}
 
-    <div class="module">
-      <h2>
-        {% if is_monthly %}
-          {% translate "Income by Category" %} - {{ current_year }}/{{ current_month|stringformat:"02d" }}
-        {% else %}
-          {% translate "Total Income" %} - {{ current_year }}
-        {% endif %}
-      </h2>
-      <p>
-        <strong>€{{ total_income|floatformat:0 }}</strong>
-      </p>
-    </div>
-
-    {% if rolling_trend %}
-      <div class="module">
-        <table>
-          <caption>{% translate "Rolling trend" %}</caption>
-          <tbody>
-            <tr>
-              <th scope="row">{% translate "Window ending" %}</th>
-              <td>{{ rolling_trend.period_year }}/{{ rolling_trend.period_month|stringformat:"02d" }}</td>
-            </tr>
-            <tr>
-              <th scope="row">{% translate "Window size" %}</th>
-              <td>
-                {% blocktranslate count months=rolling_trend.window_months %}{{ months }} month{% plural %}{{ months }} months{% endblocktranslate %}
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">{% translate "Current window" %}</th>
-              <td class="align-right nowrap">€{{ rolling_trend.rolling_total|floatformat:0 }}</td>
-            </tr>
-            <tr>
-              <th scope="row">{% translate "Previous window" %}</th>
-              <td class="align-right nowrap">€{{ rolling_trend.previous_total|floatformat:0 }}</td>
-            </tr>
-            <tr>
-              <th scope="row">{% translate "Change" %}</th>
-              <td class="align-right nowrap">
-                {% if rolling_trend.change_amount > 0 %}+{% endif %}
-                €{{ rolling_trend.change_amount|floatformat:0 }}
-                {% if rolling_trend.has_change_percent %}
-                  (
-                  {% if rolling_trend.change_percent > 0 %}+{% endif %}
-                  {{ rolling_trend.change_percent|floatformat:1 }}%)
-                {% endif %}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    {% endif %}
-
-    <div class="module">
-      <h3>
-        {% if is_monthly %}
-          {% translate "Daily Income" %}
-        {% else %}
-          {% translate "Monthly Income with Category Breakdown" %}
-        {% endif %}
-      </h3>
-      {% if is_monthly %}
-        <div class="dashboard-chart">{{ daily_chart_svg|safe }}</div>
+  <nav class="crm-tab-list" aria-label="{% translate "Income years" %}">
+    {% for year in years %}
+      {% if year == current_year %}
+        <span class="is-active">{{ year }}</span>
       {% else %}
-        <div class="dashboard-chart">{{ chart_svg|safe }}</div>
+        <a href="{% url "crm:income-year" year %}">{{ year }}</a>
       {% endif %}
-    </div>
+    {% endfor %}
+  </nav>
 
-    <div class="module">
-      <h3>{% translate "Category Distribution" %}</h3>
-      <div class="dashboard-chart">{{ pie_chart_svg|safe }}</div>
-    </div>
-
+  <section class="crm-section content">
     {% if is_monthly %}
-      <div class="module">
-        <table>
-          <caption>{% translate "Income by Category" %}</caption>
+      {% blocktranslate with month=current_month|stringformat:"02d" asvar section_title %}Income by Category - {{ current_year }}/{{ month }}{% endblocktranslate %}
+    {% else %}
+      {% blocktranslate asvar section_title %}Total Income - {{ current_year }}{% endblocktranslate %}
+    {% endif %}
+    {% include "crm/snippets/section_header.html" with section_title=section_title only %}
+    <p class="crm-metric">€{{ total_income|floatformat:0 }}</p>
+  </section>
+
+  {% if rolling_trend %}
+    <section class="crm-section content">
+      {% translate "Rolling trend" as section_title %}
+      {% include "crm/snippets/section_header.html" %}
+      <dl class="crm-detail-grid crm-detail-grid--compact">
+        <div>
+          <dt>{% translate "Window ending" %}</dt>
+          <dd>
+            {{ rolling_trend.period_year }}/{{ rolling_trend.period_month|stringformat:"02d" }}
+          </dd>
+        </div>
+        <div>
+          <dt>{% translate "Window size" %}</dt>
+          <dd>
+            {% blocktranslate count months=rolling_trend.window_months %}{{ months }} month{% plural %}{{ months }} months{% endblocktranslate %}
+          </dd>
+        </div>
+        <div>
+          <dt>{% translate "Current window" %}</dt>
+          <dd>
+            €{{ rolling_trend.rolling_total|floatformat:0 }}
+          </dd>
+        </div>
+        <div>
+          <dt>{% translate "Previous window" %}</dt>
+          <dd>
+            €{{ rolling_trend.previous_total|floatformat:0 }}
+          </dd>
+        </div>
+        <div>
+          <dt>{% translate "Change" %}</dt>
+          <dd>
+            {% if rolling_trend.change_amount > 0 %}+{% endif %}
+            €{{ rolling_trend.change_amount|floatformat:0 }}
+            {% if rolling_trend.has_change_percent %}
+              (
+              {% if rolling_trend.change_percent > 0 %}+{% endif %}
+              {{ rolling_trend.change_percent|floatformat:1 }}%)
+            {% endif %}
+          </dd>
+        </div>
+      </dl>
+    </section>
+  {% endif %}
+
+  <div class="crm-report-grid">
+    <section class="crm-section content">
+      {% if is_monthly %}
+        {% translate "Daily Income" as section_title %}
+      {% else %}
+        {% translate "Monthly Income with Category Breakdown" as section_title %}
+      {% endif %}
+      {% include "crm/snippets/section_header.html" with section_title=section_title only %}
+      <div class="crm-chart">
+        {% if is_monthly %}
+          {{ daily_chart_svg|safe }}
+        {% else %}
+          {{ chart_svg|safe }}
+        {% endif %}
+      </div>
+    </section>
+
+    <section class="crm-section content">
+      {% translate "Category Distribution" as section_title %}
+      {% include "crm/snippets/section_header.html" with section_title=section_title only %}
+      <div class="crm-chart">{{ pie_chart_svg|safe }}</div>
+    </section>
+  </div>
+
+  {% if is_monthly %}
+    <section class="crm-section content">
+      {% translate "Category income" as table_title %}
+      {% include "crm/snippets/section_header.html" with section_title=table_title only %}
+      <div class="crm-table-wrap">
+        <table class="crm-table crm-table--summary">
+          {% include "crm/snippets/table_caption.html" with table_title=table_title only %}
           <thead>
             <tr>
-              <th>{% translate "Category" %}</th>
-              <th class="align-right nowrap">{% translate "Amount (EUR)" %}</th>
+              <th scope="col">{% translate "Category" %}</th>
+              <th scope="col" class="crm-number">{% translate "Amount (EUR)" %}</th>
             </tr>
           </thead>
           <tbody>
             {% for category, amount in income_data.items %}
               <tr>
-                <td>{{ category }}</td>
-                <td class="align-right nowrap">€{{ amount|floatformat:0 }}</td>
+                <th scope="row">{{ category }}</th>
+                <td class="crm-number">€{{ amount|floatformat:0 }}</td>
               </tr>
             {% endfor %}
-            <tr class="total">
-              <td>{% translate "Total" %}</td>
-              <td class="align-right nowrap">€{{ total_income|floatformat:0 }}</td>
+            <tr class="crm-total-row">
+              <th scope="row">{% translate "Total" %}</th>
+              <td class="crm-number">€{{ total_income|floatformat:0 }}</td>
             </tr>
           </tbody>
         </table>
       </div>
-    {% else %}
-      <div class="module">
-        <table>
-          <caption>{% translate "Monthly Breakdown" %}</caption>
+    </section>
+  {% else %}
+    <section class="crm-section content">
+      {% translate "Monthly income" as table_title %}
+      {% include "crm/snippets/section_header.html" with section_title=table_title only %}
+      <div class="crm-table-wrap">
+        <table class="crm-table">
+          {% include "crm/snippets/table_caption.html" with table_title=table_title only %}
           <thead>
             <tr>
-              <th>{% translate "Month" %}</th>
-              <th class="align-right nowrap">{% translate "Amount (EUR)" %}</th>
-              <th class="align-right nowrap">{% translate "Rolling window" %}</th>
-              <th class="align-right nowrap">{% translate "Trend" %}</th>
-              <th>{% translate "Actions" %}</th>
+              <th scope="col">{% translate "Month" %}</th>
+              <th scope="col" class="crm-number">{% translate "Amount (EUR)" %}</th>
+              <th scope="col" class="crm-number">{% translate "Rolling window" %}</th>
+              <th scope="col" class="crm-number">{% translate "Trend" %}</th>
+              <th scope="col">{% translate "Actions" %}</th>
             </tr>
           </thead>
           <tbody>
             {% for row in monthly_breakdown_rows %}
               <tr>
-                <td>{{ current_year }}/{{ row.month }}</td>
-                <td class="align-right nowrap">€{{ row.amount|floatformat:0 }}</td>
-                <td class="align-right nowrap">
+                <th scope="row">{{ current_year }}/{{ row.month }}</th>
+                <td class="crm-number">€{{ row.amount|floatformat:0 }}</td>
+                <td class="crm-number">
                   {% if row.trend_available %}
                     €{{ row.rolling_total|floatformat:0 }}
                     (
                     {% blocktranslate count months=row.window_months %}{{ months }} month{% plural %}{{ months }} months{% endblocktranslate %}
                     )
                   {% else %}
-                    —
+                    -
                   {% endif %}
                 </td>
-                <td class="align-right nowrap">
+                <td class="crm-number">
                   {% if row.trend_available %}
                     {% if row.change_amount > 0 %}+{% endif %}
                     €{{ row.change_amount|floatformat:0 }}
@@ -169,17 +172,19 @@
                       {{ row.change_percent|floatformat:1 }}%)
                     {% endif %}
                   {% else %}
-                    —
+                    -
                   {% endif %}
                 </td>
                 <td>
-                  <a href="{% url 'crm:income-month' current_year row.month_number %}">{% translate "View details" %}</a>
+                  <div class="crm-row-actions">
+                    <a href="{% url "crm:income-month" current_year row.month_number %}">{% translate "View details" %}</a>
+                  </div>
                 </td>
               </tr>
             {% endfor %}
-            <tr class="total">
-              <td>{% translate "Total" %}</td>
-              <td class="align-right nowrap">€{{ total_income|floatformat:0 }}</td>
+            <tr class="crm-total-row">
+              <th scope="row">{% translate "Total" %}</th>
+              <td class="crm-number">€{{ total_income|floatformat:0 }}</td>
               <td></td>
               <td></td>
               <td></td>
@@ -187,26 +192,30 @@
           </tbody>
         </table>
       </div>
+    </section>
 
-      <div class="module">
-        <table>
-          <caption>{% translate "Income by Category (Full Year)" %}</caption>
+    <section class="crm-section content">
+      {% translate "Yearly category income" as table_title %}
+      {% include "crm/snippets/section_header.html" with section_title=table_title only %}
+      <div class="crm-table-wrap">
+        <table class="crm-table crm-table--summary">
+          {% include "crm/snippets/table_caption.html" with table_title=table_title only %}
           <thead>
             <tr>
-              <th>{% translate "Category" %}</th>
-              <th class="align-right nowrap">{% translate "Amount (EUR)" %}</th>
+              <th scope="col">{% translate "Category" %}</th>
+              <th scope="col" class="crm-number">{% translate "Amount (EUR)" %}</th>
             </tr>
           </thead>
           <tbody>
             {% for category, amount in income_data.items %}
               <tr>
-                <td>{{ category }}</td>
-                <td class="align-right nowrap">€{{ amount|floatformat:0 }}</td>
+                <th scope="row">{{ category }}</th>
+                <td class="crm-number">€{{ amount|floatformat:0 }}</td>
               </tr>
             {% endfor %}
           </tbody>
         </table>
       </div>
-    {% endif %}
-  </div>
+    </section>
+  {% endif %}
 {% endblock content %}

--- a/weblate_web/crm/templates/crm/index.html
+++ b/weblate_web/crm/templates/crm/index.html
@@ -1,248 +1,153 @@
 {% extends "crm/base.html" %}
 
-{% load i18n static %}
+{% load i18n %}
 
-{% block bodyclass %}{{ block.super }} dashboard{% endblock %}
-
-{% block extrastyle %}
-  {{ block.super }}
-  <link rel="stylesheet" href="{% static "admin/css/dashboard.css" %}">
-{% endblock extrastyle %}
+{% block bodyclass %}dashboard{% endblock %}
 
 {% block content %}
-  <div id="content-main">
-    <div class="module">
-      {% if perms.payments.view_customer %}
-        <table>
-          <caption>
-            Customers
-          </caption>
-          <tr>
-            <th scope="row" id="row-invoices">
-              <a href="{% url 'crm:customer-list' kind="all" %}">Customers</a>
-            </th>
-
+  <div class="crm-dashboard-grid">
+    {% if perms.payments.view_customer %}
+      <section class="crm-section crm-dashboard-section">
+        {% translate "Customers" as section_title %}
+        {% include "crm/snippets/section_header.html" %}
+        <div class="crm-dashboard-list">
+          <div class="crm-dashboard-item">
+            <a class="crm-dashboard-link"
+               href="{% url "crm:customer-list" kind="all" %}"
+               aria-label="{% translate "Customers" %}">
+              <strong>{% translate "Customers" %}</strong>
+              <span>{% translate "All customer records and billing contacts." %}</span>
+            </a>
             {% if perms.payments.add_customer %}
-              <td>
-                <a href="{% url "admin:payments_customer_add" %}"
-                   class="addlink"
-                   aria-describedby="row-invoices">{% translate "Add" %}</a>
-              </td>
-            {% else %}
-              <td></td>
+              <div class="crm-row-actions">
+                <a href="{% url "admin:payments_customer_add" %}">{% translate "Add" %}</a>
+              </div>
             {% endif %}
+          </div>
+          <div class="crm-dashboard-item">
+            <a class="crm-dashboard-link"
+               href="{% url "crm:customer-list" kind="active" %}"
+               aria-label="{% translate "Active customers" %}">
+              <strong>{% translate "Active customers" %}</strong>
+              <span>{% translate "Customers with current services or payments." %}</span>
+            </a>
+          </div>
+        </div>
+      </section>
+    {% endif %}
 
-            <td>
-              <a href="{% url 'crm:customer-list' kind="all" %}"
-                 class="viewlink"
-                 aria-describedby="row-invoices">{% translate "View" %}</a>
-            </td>
-          </tr>
-          <tr>
-            <th scope="row" id="row-invoices">
-              <a href="{% url 'crm:customer-list' kind="active" %}">Active customers</a>
-            </th>
-
-            <td></td>
-
-            <td>
-              <a href="{% url 'crm:customer-list' kind="active" %}"
-                 class="viewlink"
-                 aria-describedby="row-invoices">{% translate "View" %}</a>
-            </td>
-          </tr>
-        </table>
-      {% endif %}
-      {% if perms.invoices %}
-        <table>
-          <caption>
-            Invoices
-          </caption>
-          <tr>
-            <th scope="row" id="row-invoices">
-              <a href="{% url 'crm:invoice-list' kind="invoice" %}">Invoices</a>
-            </th>
-
+    {% if perms.invoices.view_invoice %}
+      <section class="crm-section crm-dashboard-section">
+        {% translate "Invoices" as section_title %}
+        {% include "crm/snippets/section_header.html" %}
+        <div class="crm-dashboard-list">
+          <div class="crm-dashboard-item">
+            <a class="crm-dashboard-link"
+               href="{% url "crm:invoice-list" kind="invoice" %}"
+               aria-label="{% translate "Invoices" %}">
+              <strong>{% translate "Invoices" %}</strong>
+              <span>{% translate "Issued invoices and receipts." %}</span>
+            </a>
             {% if perms.invoices.add_invoice %}
-              <td>
-                <a href="{% url "admin:invoices_invoice_add" %}?kind=10"
-                   class="addlink"
-                   aria-describedby="row-invoices">{% translate "Add" %}</a>
-              </td>
-            {% else %}
-              <td></td>
+              <div class="crm-row-actions">
+                <a href="{% url "admin:invoices_invoice_add" %}?kind=10">{% translate "Add" %}</a>
+              </div>
             {% endif %}
-
-            <td>
-              <a href="{% url 'crm:invoice-list' kind="invoice" %}"
-                 class="viewlink"
-                 aria-describedby="row-invoices">{% translate "View" %}</a>
-            </td>
-          </tr>
-          <tr>
-            <th scope="row" id="row-quotes">
-              <a href="{% url 'crm:invoice-list' kind="quote" %}">Quotes</a>
-            </th>
-
+          </div>
+          <div class="crm-dashboard-item">
+            <a class="crm-dashboard-link"
+               href="{% url "crm:invoice-list" kind="quote" %}"
+               aria-label="{% translate "Quotes" %}">
+              <strong>{% translate "Quotes" %}</strong>
+              <span>{% translate "Draft offers and renewal quotes." %}</span>
+            </a>
             {% if perms.invoices.add_invoice %}
-              <td>
-                <a href="{% url "admin:invoices_invoice_add" %}?kind=90"
-                   class="addlink"
-                   aria-describedby="row-invoices">{% translate "Add" %}</a>
-              </td>
-            {% else %}
-              <td></td>
+              <div class="crm-row-actions">
+                <a href="{% url "admin:invoices_invoice_add" %}?kind=90">{% translate "Add" %}</a>
+              </div>
             {% endif %}
+          </div>
+          <div class="crm-dashboard-item">
+            <a class="crm-dashboard-link"
+               href="{% url "crm:invoice-list" kind="unpaid" %}"
+               aria-label="{% translate "Unpaid invoices" %}">
+              <strong>{% translate "Unpaid invoices" %}</strong>
+              <span>{% translate "Invoices that still need payment follow-up." %}</span>
+            </a>
+          </div>
+        </div>
+      </section>
+    {% endif %}
 
-            <td>
-              <a href="{% url 'crm:invoice-list' kind="quote" %}"
-                 class="viewlink"
-                 aria-describedby="row-quotes">{% translate "View" %}</a>
-            </td>
-          </tr>
-          <tr>
-            <th scope="row" id="row-unpaid">
-              <a href="{% url 'crm:invoice-list' kind="unpaid" %}">Unpaid invoices</a>
-            </th>
-
-            <td></td>
-
-            <td>
-              <a href="{% url 'crm:invoice-list' kind="unpaid" %}"
-                 class="viewlink"
-                 aria-describedby="row-unpaid">{% translate "View" %}</a>
-            </td>
-          </tr>
-        </table>
-      {% endif %}
-      {% if perms.weblate_web.view_service %}
-        <table>
-          <caption>
-            Services
-          </caption>
-          <tr>
-            <th scope="row" id="row-invoices">
-              <a href="{% url 'crm:service-list' kind="all" %}">All services</a>
-            </th>
-
+    {% if perms.weblate_web.view_service %}
+      <section class="crm-section crm-dashboard-section">
+        {% translate "Services" as section_title %}
+        {% include "crm/snippets/section_header.html" %}
+        <div class="crm-dashboard-list">
+          <div class="crm-dashboard-item">
+            <a class="crm-dashboard-link"
+               href="{% url "crm:service-list" kind="all" %}"
+               aria-label="{% translate "All services" %}">
+              <strong>{% translate "All services" %}</strong>
+              <span>{% translate "Hosted, dedicated, and support services." %}</span>
+            </a>
             {% if perms.weblate_web.add_service %}
-              <td>
-                <a href="{{ model.add_url }}" class="addlink" aria-describedby="row-invoices">{% translate "Add" %}</a>
-              </td>
-            {% else %}
-              <td></td>
+              <div class="crm-row-actions">
+                <a href="{% url "admin:weblate_web_service_add" %}">{% translate "Add" %}</a>
+              </div>
             {% endif %}
+          </div>
+          <div class="crm-dashboard-item">
+            <a class="crm-dashboard-link"
+               href="{% url "crm:service-list" kind="expired" %}"
+               aria-label="{% translate "Expired services" %}">
+              <strong>{% translate "Expired services" %}</strong>
+              <span>{% translate "Renewable services past their expiration date." %}</span>
+            </a>
+          </div>
+          <div class="crm-dashboard-item">
+            <a class="crm-dashboard-link"
+               href="{% url "crm:service-list" kind="dedicated" %}"
+               aria-label="{% translate "Dedicated hosting services" %}">
+              <strong>{% translate "Dedicated hosting services" %}</strong>
+              <span>{% translate "Dedicated hosting subscriptions." %}</span>
+            </a>
+          </div>
+          <div class="crm-dashboard-item">
+            <a class="crm-dashboard-link"
+               href="{% url "crm:service-list" kind="extended" %}"
+               aria-label="{% translate "Extended support services" %}">
+              <strong>{% translate "Extended support services" %}</strong>
+              <span>{% translate "Extended support subscriptions." %}</span>
+            </a>
+          </div>
+          <div class="crm-dashboard-item">
+            <a class="crm-dashboard-link"
+               href="{% url "crm:service-list" kind="premium" %}"
+               aria-label="{% translate "Premium support services" %}">
+              <strong>{% translate "Premium support services" %}</strong>
+              <span>{% translate "Premium support subscriptions." %}</span>
+            </a>
+          </div>
+        </div>
+      </section>
+    {% endif %}
 
-            <td>
-              <a href="{% url 'crm:service-list' kind="all" %}"
-                 class="viewlink"
-                 aria-describedby="row-invoices">{% translate "View" %}</a>
-            </td>
-          </tr>
-          <tr>
-            <th scope="row" id="row-invoices">
-              <a href="{% url 'crm:service-list' kind="expired" %}">Expired services</a>
-            </th>
-
-            <td></td>
-
-            <td>
-              <a href="{% url 'crm:service-list' kind="expired" %}"
-                 class="viewlink"
-                 aria-describedby="row-invoices">{% translate "View" %}</a>
-            </td>
-          </tr>
-          <tr>
-            <th scope="row" id="row-dedicated">
-              <a href="{% url 'crm:service-list' kind="dedicated" %}">Dedicated hosting services</a>
-            </th>
-
-            <td></td>
-
-            <td>
-              <a href="{% url 'crm:service-list' kind="dedicated" %}"
-                 class="viewlink"
-                 aria-describedby="row-dedicated">{% translate "View" %}</a>
-            </td>
-          </tr>
-          <tr>
-            <th scope="row" id="row-invoices">
-              <a href="{% url 'crm:service-list' kind="extended" %}">Extended support services</a>
-            </th>
-
-            <td></td>
-
-            <td>
-              <a href="{% url 'crm:service-list' kind="extended" %}"
-                 class="viewlink"
-                 aria-describedby="row-invoices">{% translate "View" %}</a>
-            </td>
-          </tr>
-          <tr>
-            <th scope="row" id="row-invoices">
-              <a href="{% url 'crm:service-list' kind="premium" %}">Premium support services</a>
-            </th>
-
-            <td></td>
-
-            <td>
-              <a href="{% url 'crm:service-list' kind="premium" %}"
-                 class="viewlink"
-                 aria-describedby="row-invoices">{% translate "View" %}</a>
-            </td>
-          </tr>
-        </table>
-      {% endif %}
-      {% if perms.invoices.view_income %}
-        <table>
-          <caption>
-            Income Tracking
-          </caption>
-          <tr>
-            <th scope="row" id="row-income">
-              <a href="{% url 'crm:income' %}">Income</a>
-            </th>
-
-            <td></td>
-
-            <td>
-              <a href="{% url 'crm:income' %}" class="viewlink" aria-describedby="row-income">{% translate "View" %}</a>
-            </td>
-          </tr>
-        </table>
-      {% endif %}
-      {% comment %}
-      <table>
-        <caption>
-          <a href="TODO" class="section">{{ app.name }}xx</a>
-        </caption>
-        <tr>
-          <th scope="row" id="row-TODO">
-            <a href="TODO">TODO</a>
-          </th>
-
-          {% if model.add_url %}
-            <td>
-              <a href="{{ model.add_url }}" class="addlink" aria-describedby="row-TODO">{% translate 'Add' %}</a>
-            </td>
-          {% else %}
-            <td></td>
-          {% endif %}
-
-          {% if model.view_only %}
-            <td>
-              <a href="{{ model.admin_url }}" class="viewlink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{% translate 'View' %}</a>
-            </td>
-          {% elif models.edit %}
-            <td>
-              <a href="{{ model.admin_url }}" class="changelink" aria-describedby="{{ app.app_label }}-{{ model_name }}">{% translate 'Change' %}</a>
-            </td>
-          {% else %}
-            <td></td>
-          {% endif %}
-        </tr>
-      </table>
-      {% endcomment %}
-    </div>
+    {% if perms.invoices.view_income %}
+      <section class="crm-section crm-dashboard-section">
+        {% translate "Income tracking" as section_title %}
+        {% include "crm/snippets/section_header.html" %}
+        <div class="crm-dashboard-list">
+          <div class="crm-dashboard-item">
+            <a class="crm-dashboard-link"
+               href="{% url "crm:income" %}"
+               aria-label="{% translate "Income" %}">
+              <strong>{% translate "Income" %}</strong>
+              <span>{% translate "Yearly and monthly income breakdowns." %}</span>
+            </a>
+          </div>
+        </div>
+      </section>
+    {% endif %}
   </div>
 {% endblock content %}

--- a/weblate_web/crm/templates/crm/interaction_detail.html
+++ b/weblate_web/crm/templates/crm/interaction_detail.html
@@ -3,72 +3,87 @@
 {% load i18n %}
 
 {% block breadcrum_list %}
-  › <a href="{% url "crm:customer-list" kind="all" %}">Customers</a>
-  › <a href="{% url "crm:customer-detail" pk=object.customer.pk %}">{{ object.customer.verbose_name }}</a>
+  <span aria-hidden="true">›</span>
+  <a href="{% url "crm:customer-list" kind="all" %}">{% translate "Customers" %}</a>
+  <span aria-hidden="true">›</span>
+  <a href="{% url "crm:customer-detail" pk=object.customer.pk %}?tab=interactions">{{ object.customer.verbose_name }}</a>
 {% endblock breadcrum_list %}
 
 {% block content %}
-  <section class="content">
-    <h2>{{ object.summary }}</h2>
-    <table>
-      <tr>
-        <th>{% translate "Timestamp" %}</th>
-        <td>{{ object.timestamp }}</td>
-      </tr>
-      <tr>
-        <th>{% translate "Customer" %}</th>
-        <td>
-          <a href="{% url "crm:customer-detail" pk=object.customer.pk %}">{{ object.customer.verbose_name }}</a>
-        </td>
-      </tr>
-      <tr>
-        <th>{% translate "User" %}</th>
-        <td>{{ object.user.username }}</td>
-      </tr>
-      <tr>
-        <th>{% translate "Origin" %}</th>
-        <td>{{ object.get_origin_display }}</td>
-      </tr>
-    </table>
+  <section class="crm-section content">
+    {% translate "Interaction" as section_title %}
+    {% include "crm/snippets/section_header.html" %}
+    <dl class="crm-detail-grid">
+      <div>
+        <dt>{% translate "Timestamp" %}</dt>
+        <dd>
+          {{ object.timestamp }}
+        </dd>
+      </div>
+      <div>
+        <dt>{% translate "Customer" %}</dt>
+        <dd>
+          <a href="{% url "crm:customer-detail" pk=object.customer.pk %}?tab=interactions">{{ object.customer.verbose_name }}</a>
+        </dd>
+      </div>
+      <div>
+        <dt>{% translate "User" %}</dt>
+        <dd>
+          {{ object.user.username }}
+        </dd>
+      </div>
+      <div>
+        <dt>{% translate "Origin" %}</dt>
+        <dd>
+          {{ object.get_origin_display }}
+        </dd>
+      </div>
+    </dl>
+  </section>
 
-    {% with detail_rows=object.detail_rows %}
-      {% if detail_rows or object.attachment %}
-        <h3>{% translate "Details" %}</h3>
-        <table>
+  {% with detail_rows=object.detail_rows %}
+    {% if detail_rows or object.attachment %}
+      <section class="crm-section content">
+        {% translate "Details" as section_title %}
+        {% include "crm/snippets/section_header.html" %}
+        <dl class="crm-detail-grid">
           {% for detail in detail_rows %}
-            <tr>
-              <th>{{ detail.label }}</th>
-              <td>
+            <div>
+              <dt>{{ detail.label }}</dt>
+              <dd>
                 {% if detail.url %}
                   <a href="{{ detail.url }}">{{ detail.value }}</a>
                 {% else %}
                   {{ detail.value }}
                 {% endif %}
-              </td>
-            </tr>
+              </dd>
+            </div>
           {% endfor %}
           {% if object.attachment %}
-            <tr>
-              <th>{% translate "Attachment" %}</th>
-              <td>
+            <div>
+              <dt>{% translate "Attachment" %}</dt>
+              <dd>
                 <a href="{{ object.attachment_download_url }}">{{ object.attachment_filename }}</a>
-              </td>
-            </tr>
+              </dd>
+            </div>
           {% endif %}
-        </table>
-      {% endif %}
-    {% endwith %}
+        </dl>
+      </section>
+    {% endif %}
+  {% endwith %}
 
-    {% if object.content %}
-      <h3>{% translate "Content" %}</h3>
+  {% if object.content %}
+    <section class="crm-section content">
+      {% translate "Content" as section_title %}
+      {% include "crm/snippets/section_header.html" %}
       {% if object.content_is_html %}
         <iframe title="{% translate "Interaction content" %}"
                 class="interaction-content"
                 sandbox
                 srcdoc="{{ object.content }}"></iframe>
       {% else %}
-        <pre>{{ object.content }}</pre>
+        <pre class="crm-preformatted">{{ object.content }}</pre>
       {% endif %}
-    {% endif %}
-  </section>
+    </section>
+  {% endif %}
 {% endblock content %}

--- a/weblate_web/crm/templates/crm/pagination.html
+++ b/weblate_web/crm/templates/crm/pagination.html
@@ -1,15 +1,21 @@
-<div class="pagination">
-  <span class="step-links">
-    {% if page_obj.has_previous %}
-      <a href="?page=1">« first</a>
-      <a href="?page={{ page_obj.previous_page_number }}">previous</a>
-    {% endif %}
+{% load i18n %}
 
-    <span class="current">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.</span>
+{% if is_paginated %}
+  <nav class="crm-pagination" aria-label="{% translate "Pagination" %}">
+    <div class="crm-pagination__links">
+      {% if page_obj.has_previous %}
+        <a href="?page=1{% if query %}&amp;q={{ query|urlencode }}{% endif %}">{% translate "First" %}</a>
+        <a href="?page={{ page_obj.previous_page_number }}{% if query %}&amp;q={{ query|urlencode }}{% endif %}">{% translate "Previous" %}</a>
+      {% endif %}
 
-    {% if page_obj.has_next %}
-      <a href="?page={{ page_obj.next_page_number }}">next</a>
-      <a href="?page={{ page_obj.paginator.num_pages }}">last »</a>
-    {% endif %}
-  </span>
-</div>
+      <span>
+        {% blocktranslate with page=page_obj.number pages=page_obj.paginator.num_pages %}Page {{ page }} of {{ pages }}{% endblocktranslate %}
+      </span>
+
+      {% if page_obj.has_next %}
+        <a href="?page={{ page_obj.next_page_number }}{% if query %}&amp;q={{ query|urlencode }}{% endif %}">{% translate "Next" %}</a>
+        <a href="?page={{ page_obj.paginator.num_pages }}{% if query %}&amp;q={{ query|urlencode }}{% endif %}">{% translate "Last" %}</a>
+      {% endif %}
+    </div>
+  </nav>
+{% endif %}

--- a/weblate_web/crm/templates/crm/snippets/empty.html
+++ b/weblate_web/crm/templates/crm/snippets/empty.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+
+<div class="crm-empty">
+  <p>
+    {% if empty_message %}
+      {{ empty_message }}
+    {% else %}
+      {% translate "No records found." %}
+    {% endif %}
+  </p>
+</div>

--- a/weblate_web/crm/templates/crm/snippets/search_form.html
+++ b/weblate_web/crm/templates/crm/snippets/search_form.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+
+<form class="crm-toolbar crm-search" method="get">
+  <div class="crm-field crm-field--inline">
+    {{ search_form.q.label_tag }}
+    {{ search_form.q }}
+  </div>
+  <div class="crm-toolbar__actions">
+    <button class="crm-button" type="submit">{% translate "Search" %}</button>
+    {% if query %}
+      <a class="crm-button crm-button--secondary" href="{{ request.path }}">{% translate "Clear" %}</a>
+    {% endif %}
+  </div>
+</form>

--- a/weblate_web/crm/templates/crm/snippets/section_header.html
+++ b/weblate_web/crm/templates/crm/snippets/section_header.html
@@ -1,0 +1,9 @@
+{% if section_title or section_description or section_actions %}
+  <header class="crm-section__header">
+    <div>
+      {% if section_title %}<h2>{{ section_title }}</h2>{% endif %}
+      {% if section_description %}<p>{{ section_description }}</p>{% endif %}
+    </div>
+    {% if section_actions %}<div class="crm-section__actions">{{ section_actions }}</div>{% endif %}
+  </header>
+{% endif %}

--- a/weblate_web/crm/templates/crm/snippets/table_caption.html
+++ b/weblate_web/crm/templates/crm/snippets/table_caption.html
@@ -1,0 +1,1 @@
+{% if table_title %}<caption class="crm-sr-only">{{ table_title }}</caption>{% endif %}

--- a/weblate_web/crm/templates/invoices/invoice_detail.html
+++ b/weblate_web/crm/templates/invoices/invoice_detail.html
@@ -1,102 +1,188 @@
 {% extends "crm/base.html" %}
 
-{% load i18n static %}
+{% load i18n %}
 
 {% block breadcrum_list %}
-  › <a href="{% url "crm:invoice-list" kind="all" %}">Invoices</a>
+  <span aria-hidden="true">›</span>
+  <a href="{% url "crm:invoice-list" kind="all" %}">{% translate "Invoices" %}</a>
 {% endblock breadcrum_list %}
 
-{% block content %}
-  <section class="content">
-    <h2>{{ object.number }}</h2>
-    <p>
-      <a href="{% url 'crm:customer-detail' pk=object.customer.pk %}">{{ object.customer.verbose_name }}</a>
-      <br>
-      {{ object.get_kind_display }}
-      {% if object.is_paid %}
-        paid
-      {% elif object.is_payable %}
-        <strong>unpaid</strong>
+{% block page_actions %}
+  <div class="crm-page-actions">
+    {% with download_url=object.get_download_url %}
+      {% if download_url %}
+        <a class="crm-button crm-button--secondary" href="{{ download_url }}">{% translate "Download" %}</a>
+        {% if object.is_paid %}
+          <a class="crm-button crm-button--secondary" href="{{ download_url }}?receipt=1">{% translate "Receipt" %}</a>
+        {% endif %}
       {% endif %}
-      / {{ object.get_category_display }}
-      <br>
-      Issued {{ object.issue_date }}, due {{ object.due_date }}
-      <br>
+    {% endwith %}
+    <a class="crm-button crm-button--secondary"
+       href="{% url "admin:invoices_invoice_change" object_id=object.pk %}">{% translate "Edit in admin" %}</a>
+  </div>
+{% endblock page_actions %}
+
+{% block content %}
+  <section class="crm-section content">
+    {% translate "Invoice" as section_title %}
+    {% include "crm/snippets/section_header.html" %}
+    <p class="crm-summary-line">
+      <a href="{% url "crm:customer-detail" pk=object.customer.pk %}">{{ object.customer.verbose_name }}</a>
+      <span>{{ object.get_kind_display }}</span>
+      {% if object.is_paid %}
+        <span class="crm-badge crm-badge--success">{% translate "Paid" %}</span>
+      {% elif object.is_payable %}
+        <span class="crm-badge crm-badge--warning">{% translate "Unpaid" %}</span>
+      {% endif %}
+      <span>{{ object.get_category_display }}</span>
+    </p>
+    <dl class="crm-detail-grid">
+      <div>
+        <dt>{% translate "Number" %}</dt>
+        <dd>
+          {{ object.number }}
+        </dd>
+      </div>
+      <div>
+        <dt>{% translate "Issued" %}</dt>
+        <dd>
+          {{ object.issue_date }}
+        </dd>
+      </div>
+      <div>
+        <dt>{% translate "Due" %}</dt>
+        <dd>
+          {{ object.due_date }}
+        </dd>
+      </div>
+      <div>
+        <dt>{% translate "Amount" %}</dt>
+        <dd>
+          {{ object.display_total_amount }}
+        </dd>
+      </div>
+      {% if object.discount %}
+        <div>
+          <dt>{% translate "Discount" %}</dt>
+          <dd>
+            {{ object.discount }}
+          </dd>
+        </div>
+      {% endif %}
       {% if object.parent %}
-        Generated from <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.number }}</a>
-        <br>
+        <div>
+          <dt>{% translate "Generated from" %}</dt>
+          <dd>
+            <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.number }}</a>
+          </dd>
+        </div>
       {% endif %}
       {% for child in object.invoice_set.all %}
-        Followup as <a href="{{ child.get_absolute_url }}">{{ child.number }}</a>
-        <br>
+        <div>
+          <dt>{% translate "Followup as" %}</dt>
+          <dd>
+            <a href="{{ child.get_absolute_url }}">{{ child.number }}</a>
+          </dd>
+        </div>
       {% endfor %}
       {% if object.customer_reference %}
-        Customer reference: {{ object.customer_reference }}
-        <br>
+        <div>
+          <dt>{% translate "Customer reference" %}</dt>
+          <dd>
+            {{ object.customer_reference }}
+          </dd>
+        </div>
       {% endif %}
       {% if object.customer_note %}
-        Customer note: {{ object.customer_note }}
-        <br>
+        <div>
+          <dt>{% translate "Customer note" %}</dt>
+          <dd>
+            {{ object.customer_note }}
+          </dd>
+        </div>
       {% endif %}
-      Amount: {{ object.display_total_amount }}
-      <br>
-      {% if object.discount %}
-        Discount: {{ object.discount }}
-        <br>
-      {% endif %}
-      {% with download_url=object.get_download_url %}
-        {% if download_url %}
-          <a href="{{ download_url }}">{% translate "Download" %}</a>
-          {% if object.is_paid %}
-            <a href="{{ download_url }}?receipt=1">{% translate "Receipt" %}</a>
-          {% endif %}
-        {% endif %}
-      {% endwith %}
-      <a href="{% url "admin:invoices_invoice_change" object_id=object.pk %}">{% translate "Edit" %}</a>
-    </p>
-    <table>
-      {% for item in object.all_items %}
-        <tr>
-          <td>
-            {{ item.description }}
-            <br>
-            {% if item.has_date_range %}<em class="period">{{ item.get_date_range_display }}</em>{% endif %}
-          </td>
-          <td>{{ item.display_quantity }}</td>
-          <td>{{ item.display_price }}</td>
-          <td>{{ item.display_total_price }}</td>
-        </tr>
-      {% endfor %}
-    </table>
-    {% if refund_form %}
-      <h2>{% translate "Confirm refund done" %}</h2>
+    </dl>
+  </section>
+
+  <section class="crm-section content">
+    {% translate "Invoice items" as table_title %}
+    {% include "crm/snippets/section_header.html" with section_title=table_title only %}
+    <div class="crm-table-wrap">
+      <table class="crm-table">
+        {% include "crm/snippets/table_caption.html" with table_title=table_title only %}
+        <thead>
+          <tr>
+            <th scope="col">{% translate "Description" %}</th>
+            <th scope="col" class="crm-number">{% translate "Quantity" %}</th>
+            <th scope="col" class="crm-number">{% translate "Price" %}</th>
+            <th scope="col" class="crm-number">{% translate "Total" %}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for item in object.all_items %}
+            <tr>
+              <th scope="row">
+                {{ item.description }}
+                {% if item.has_date_range %}
+                  <span class="crm-muted">{{ item.get_date_range_display }}</span>
+                {% endif %}
+              </th>
+              <td class="crm-number">{{ item.display_quantity }}</td>
+              <td class="crm-number">{{ item.display_price }}</td>
+              <td class="crm-number">{{ item.display_total_price }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  {% if refund_form %}
+    <section class="crm-section content">
+      {% translate "Confirm refund done" as section_title %}
+      {% include "crm/snippets/section_header.html" %}
       <p>{% translate "Use this after the refund or chargeback has been completed." %}</p>
-      <form method="post">
+      <form class="crm-form-panel crm-form-panel--compact" method="post">
         {% csrf_token %}
-        {{ refund_form }}
-        {% translate "Confirm refund done" as confirm_refund_label %}
-        <input type="submit" name="confirm_refund" value="{{ confirm_refund_label }}">
+        <div class="crm-form-panel__body">{{ refund_form }}</div>
+        <div class="crm-form-panel__actions">
+          {% translate "Confirm refund done" as confirm_refund_label %}
+          <input class="crm-button"
+                 type="submit"
+                 name="confirm_refund"
+                 value="{{ confirm_refund_label }}">
+        </div>
       </form>
-    {% endif %}
-    {% if convert_form %}
-      <h2>{% translate "Issue invoice" %}</h2>
+    </section>
+  {% endif %}
+
+  {% if convert_form %}
+    <section class="crm-section content">
+      {% translate "Issue invoice" as section_title %}
+      {% include "crm/snippets/section_header.html" %}
       <details class="crm-danger-action">
         <summary>{% translate "Issue invoice from quote" %}</summary>
         <p>
           {% blocktranslate %}This creates a final invoice matching this quote. Use Download if you only need the quote PDF.{% endblocktranslate %}
         </p>
-        <form method="post">
+        <form class="crm-form-panel crm-form-panel--compact" method="post">
           {% csrf_token %}
-          {{ convert_form }}
-          <label>
-            <input type="checkbox" name="confirm_invoice" value="1" required>
-            {% translate "I confirm that I want to issue a final invoice." %}
-          </label>
-          <br>
-          {% translate "Issue invoice" as issue_invoice_label %}
-          <input type="submit" name="invoice" value="{{ issue_invoice_label }}">
+          <div class="crm-form-panel__body">
+            {{ convert_form }}
+            <label class="crm-check">
+              <input type="checkbox" name="confirm_invoice" value="1" required>
+              <span>{% translate "I confirm that I want to issue a final invoice." %}</span>
+            </label>
+          </div>
+          <div class="crm-form-panel__actions">
+            {% translate "Issue invoice" as issue_invoice_label %}
+            <input class="crm-button"
+                   type="submit"
+                   name="invoice"
+                   value="{{ issue_invoice_label }}">
+          </div>
         </form>
       </details>
-    {% endif %}
-  </section>
+    </section>
+  {% endif %}
 {% endblock content %}

--- a/weblate_web/crm/templates/invoices/invoice_list.html
+++ b/weblate_web/crm/templates/invoices/invoice_list.html
@@ -1,12 +1,35 @@
 {% extends "crm/base.html" %}
 
-{% load i18n static %}
+{% load i18n %}
 
 {% block content %}
-  <section class="content">
-    <table>
-      {% include "invoices/invoice_list_content.html" %}
-    </table>
+  <section class="crm-section">
+    {% translate "Invoice list" as table_title %}
+    {% include "crm/snippets/section_header.html" with section_title=table_title only %}
+    {% if object_list %}
+      <div class="crm-table-wrap">
+        <table class="crm-table">
+          {% include "crm/snippets/table_caption.html" with table_title=table_title only %}
+          <thead>
+            <tr>
+              <th scope="col">{% translate "Number" %}</th>
+              <th scope="col">{% translate "Status" %}</th>
+              <th scope="col">{% translate "Kind" %}</th>
+              <th scope="col" class="crm-number">{% translate "Amount" %}</th>
+              <th scope="col">{% translate "Description" %}</th>
+              <th scope="col">{% translate "Customer" %}</th>
+              <th scope="col">{% translate "Actions" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% include "invoices/invoice_list_content.html" %}
+          </tbody>
+        </table>
+      </div>
+    {% else %}
+      {% translate "No invoices match the current filters." as empty_message %}
+      {% include "crm/snippets/empty.html" %}
+    {% endif %}
   </section>
   {% include "crm/pagination.html" %}
 {% endblock content %}

--- a/weblate_web/crm/templates/invoices/invoice_list_content.html
+++ b/weblate_web/crm/templates/invoices/invoice_list_content.html
@@ -1,26 +1,40 @@
+{% load i18n %}
+
 {% for invoice in object_list %}
   <tr>
-    <th>{{ invoice.number }}</th>
+    <th scope="row">
+      <a href="{{ invoice.get_absolute_url }}">{{ invoice.number }}</a>
+    </th>
     <td>
       {% if invoice.is_paid %}
-        paid
+        <span class="crm-badge crm-badge--success">{% translate "Paid" %}</span>
       {% elif invoice.is_payable %}
         {% if invoice.due_date > today.date %}
-          unpaid, due {{ invoice.due_date }}
+          <span class="crm-badge crm-badge--warning">{% translate "Unpaid" %}</span>
+          <span class="crm-muted">{{ invoice.due_date }}</span>
         {% else %}
-          <strong>unpaid, due {{ invoice.due_date }}</strong>
+          <span class="crm-badge crm-badge--danger">{% translate "Overdue" %}</span>
+          <span class="crm-muted">{{ invoice.due_date }}</span>
         {% endif %}
+      {% else %}
+        <span class="crm-muted">-</span>
       {% endif %}
     </td>
     <td>{{ invoice.get_kind_display }}</td>
-    <td>{{ invoice.display_total_amount }}</td>
+    <td class="crm-number">{{ invoice.display_total_amount }}</td>
     <td>{{ invoice.get_description }}</td>
-    <td>{{ invoice.customer }}</td>
     <td>
-      <a href="{{ invoice.get_absolute_url }}">View</a>
-      {% with download_url=invoice.get_download_url %}
-        {% if download_url %}<a href="{{ download_url }}">Download</a>{% endif %}
-      {% endwith %}
+      <a href="{{ invoice.customer.get_absolute_url }}">{{ invoice.customer.verbose_name }}</a>
+    </td>
+    <td>
+      <div class="crm-row-actions">
+        <a href="{{ invoice.get_absolute_url }}">{% translate "View" %}</a>
+        {% with download_url=invoice.get_download_url %}
+          {% if download_url %}
+            <a href="{{ download_url }}">{% translate "Download" %}</a>
+          {% endif %}
+        {% endwith %}
+      </div>
     </td>
   </tr>
 {% endfor %}

--- a/weblate_web/crm/templates/payments/customer_detail.html
+++ b/weblate_web/crm/templates/payments/customer_detail.html
@@ -1,162 +1,425 @@
 {% extends "crm/base.html" %}
 
-{% load i18n static timestamps %}
+{% load i18n timestamps %}
 
 {% block breadcrum_list %}
-  › <a href="{% url "crm:customer-list" kind="all" %}">Customers</a>
+  <span aria-hidden="true">›</span>
+  <a href="{% url "crm:customer-list" kind="all" %}">{% translate "Customers" %}</a>
 {% endblock breadcrum_list %}
 
+{% block page_actions %}
+  <div class="crm-page-actions">
+    <a class="crm-button crm-button--secondary"
+       href="{% url "admin:payments_customer_change" object_id=object.pk %}">{% translate "Edit in admin" %}</a>
+  </div>
+{% endblock page_actions %}
+
 {% block content %}
-  <section class="content">
-    <p>
-      {{ object.name }}
-      <br>
-      {{ object.get_notify_emails|join:", " }}
-      <br>
-      {% if object.vat %}
-        {{ object.vat }} (
-        {% if object.vat_recently_validated %}
-          validated on {{ object.vat_validated }}
-        {% else %}
-          <strong>not validated</strong>
+  <nav class="crm-tab-list" aria-label="{% translate "Customer sections" %}">
+    <a href="{{ object.get_absolute_url }}"
+       class="{% if active_tab == "overview" %}is-active{% endif %}"
+       {% if active_tab == "overview" %}aria-current="page"{% endif %}>{% translate "Overview" %}</a>
+    <a href="{{ object.get_absolute_url }}?tab=interactions"
+       class="{% if active_tab == "interactions" %}is-active{% endif %}"
+       {% if active_tab == "interactions" %}aria-current="page"{% endif %}>{% translate "Interactions" %}</a>
+    <a href="{{ object.get_absolute_url }}?tab=invoices"
+       class="{% if active_tab == "invoices" %}is-active{% endif %}"
+       {% if active_tab == "invoices" %}aria-current="page"{% endif %}>{% translate "Invoices" %}</a>
+    <a href="{{ object.get_absolute_url }}?tab=payments"
+       class="{% if active_tab == "payments" %}is-active{% endif %}"
+       {% if active_tab == "payments" %}aria-current="page"{% endif %}>{% translate "Payments" %}</a>
+  </nav>
+
+  {% if active_tab == "overview" %}
+    <section class="crm-section content">
+      {% translate "Customer" as section_title %}
+      {% include "crm/snippets/section_header.html" %}
+      <dl class="crm-detail-grid">
+        <div>
+          <dt>{% translate "Name" %}</dt>
+          <dd>
+            {{ object.name }}
+          </dd>
+        </div>
+        <div>
+          <dt>{% translate "Notification e-mails" %}</dt>
+          <dd>
+            {{ object.get_notify_emails|join:", " }}
+          </dd>
+        </div>
+        {% if object.vat %}
+          <div>
+            <dt>{% translate "VAT" %}</dt>
+            <dd>
+              {{ object.vat }}
+              {% if object.vat_recently_validated %}
+                <span class="crm-muted">
+                  {% blocktranslate with validated=object.vat_validated %}validated on {{ validated }}{% endblocktranslate %}
+                </span>
+              {% else %}
+                <strong>{% translate "not validated" %}</strong>
+              {% endif %}
+            </dd>
+          </div>
         {% endif %}
-        )
-        <br>
-      {% endif %}
-      {{ object.address }},
-      {% if object.address2 %}{{ object.address2 }},{% endif %}
-      {{ object.city }}
-      <br>
-      {{ object.get_country_display }}
-      <br>
-      {% if object.end_client %}
-        End client: {{ object.end_client }}
-        <br>
-      {% endif %}
-      {% if object.contact_point %}
-        {% translate "Contact point" %}: {{ object.contact_point }}
-        <br>
-      {% endif %}
-      {% if object.accounting_reference %}
-        {% translate "Accounting reference" %}: {{ object.accounting_reference }}
-        <br>
-      {% endif %}
-      {% if object.upcoming_payment_notification_days %}
-        Additional upcoming payment notification:
-        {{ object.upcoming_payment_notification_days }} days before due date
-        <br>
-      {% endif %}
-      {% if object.zammad_id %}
-        <a href="https://care.weblate.org/#organization/profile/{{ object.zammad_id }}">View in Zammad</a>
-        <br />
-      {% endif %}
-      <a href="{% url "admin:payments_customer_change" object_id=object.pk %}">Edit</a>
-    </p>
-    <h2>Actions</h2>
-    <form action="{% url "crm:customer-merge" pk=object.pk %}" method="get">
-      {{ merge_form.merge.label_tag }}
-      {{ merge_form.merge }}
-      {% translate "Review merge" as review_merge_label %}
-      <input type="submit" value="{{ review_merge_label }}">
-    </form>
-    {% if can_add_customer_user %}
-      <form method="post">
-        <p>{% translate "Add user to customer" %}</p>
-        {% csrf_token %}
-        {{ customer_user_form }}
-        <input type="submit" name="add_customer_user" value="{% translate "Add user" %}">
-      </form>
-    {% endif %}
+        <div>
+          <dt>{% translate "Address" %}</dt>
+          <dd>
+            {{ object.address }}{% if object.address2 %}, {{ object.address2 }}{% endif %},
+            {{ object.city }}
+          </dd>
+        </div>
+        <div>
+          <dt>{% translate "Country" %}</dt>
+          <dd>
+            {{ object.get_country_display }}
+          </dd>
+        </div>
+        {% if object.end_client %}
+          <div>
+            <dt>{% translate "End client" %}</dt>
+            <dd>
+              {{ object.end_client }}
+            </dd>
+          </div>
+        {% endif %}
+        {% if object.contact_point %}
+          <div>
+            <dt>{% translate "Contact point" %}</dt>
+            <dd>
+              {{ object.contact_point }}
+            </dd>
+          </div>
+        {% endif %}
+        {% if object.accounting_reference %}
+          <div>
+            <dt>{% translate "Accounting reference" %}</dt>
+            <dd>
+              {{ object.accounting_reference }}
+            </dd>
+          </div>
+        {% endif %}
+        {% if object.upcoming_payment_notification_days %}
+          <div>
+            <dt>{% translate "Payment reminder" %}</dt>
+            <dd>
+              {% blocktranslate count days=object.upcoming_payment_notification_days %}Additional notification {{ days }} day before due date{% plural %}Additional notification {{ days }} days before due date{% endblocktranslate %}
+            </dd>
+          </div>
+        {% endif %}
+        {% if object.zammad_id %}
+          <div>
+            <dt>{% translate "Zammad" %}</dt>
+            <dd>
+              <a href="https://care.weblate.org/#organization/profile/{{ object.zammad_id }}">{% translate "View in Zammad" %}</a>
+            </dd>
+          </div>
+        {% endif %}
+      </dl>
+    </section>
 
-    <h2>Services</h2>
-    {% include "weblate_web/service_list_content.html" with object_list=services %}
-    {% if not services %}
-      <form method="post">
-        <p>Invoice new service</p>
-        {% csrf_token %}
-        {{ new_subscription_form }}
-        <input type="submit" value="Create">
-      </form>
-    {% endif %}
-    <h2>Agreements</h2>
-    <table>
-      {% for agreement in object.agreement_set.order %}
-        <tr>
-          <td>{{ agreement.signed }}</td>
-          <td>{{ agreement.get_kind_display }}</td>
-          <td>
-            <a href="{% url 'agreement-download' pk=agreement.pk %}">Download</a>
-          </td>
-        </tr>
-      {% endfor %}
-    </table>
-    {% if perms.legal.add_agreement %}
-      <a href="{% url "admin:legal_agreement_add" %}?customer={{ object.pk }}"
-         class="addlink">{% translate "Add new agreement" %}</a>
-    {% endif %}
-    <h2>Donations</h2>
-    <table>
-      {% for donation in donations %}
-        <tr>
-          <td>{{ donation.created }}</td>
-          <td>{{ donation.donation_subscription.package.donation_reward_display }}</td>
-          <td>{{ donation.get_donation_amount }} EUR</td>
-          <td>
-            <a href="{% url 'admin:weblate_web_service_change' object_id=donation.pk %}">Edit</a>
-          </td>
-        </tr>
-      {% endfor %}
-    </table>
-    <h2>Invoices</h2>
-    <table>
-      {% include "invoices/invoice_list_content.html" with object_list=object.invoice_set.order %}
-    </table>
-    {% if perms.invoices.add_invoice %}
-      <a href="{% url "admin:invoices_invoice_add" %}?customer={{ object.pk }}"
-         class="addlink">{% translate "Issue new invoice" %}</a>
-    {% endif %}
-    <h2>Interactions</h2>
-    <form method="post">
-      {% csrf_token %}
-      {{ manual_interaction_form }}
-      <input type="submit" name="add_manual_note" value="{% translate "Add note" %}">
-    </form>
-    <table>
-      {% for interaction in object.interaction_set.order %}
-        <tr>
-          <td>{{ interaction.timestamp }}</td>
-          <td>{{ interaction.user.username }}</td>
-          <td>{{ interaction.get_origin_display }}</td>
-          <td>{{ interaction.summary }}</td>
-          <td>
-            {% with primary=interaction.primary_content %}
-              {% if primary and primary != interaction.summary %}{{ primary|linebreaksbr }}{% endif %}
-            {% endwith %}
-          </td>
-          <td>
-            {% if interaction.has_detail_page %}
-              <a href="{% url 'crm:interaction-detail' pk=interaction.pk %}" target="_blank">View</a>
-            {% endif %}
-            {% if interaction.attachment %}<a href="{{ interaction.attachment_download_url }}">Download</a>{% endif %}
-          </td>
-        </tr>
-      {% endfor %}
-    </table>
-    <h2>Payments</h2>
-    <table>
-      {% for payment in object.payment_set.order %}
-        <tr>
-          <td>{{ payment.created }}</td>
-          <td>{{ payment.get_state_display }}</td>
-          <td>{{ payment.get_amount_display }} {{ payment.get_currency_display }}</td>
-          <td>{{ payment.description }}</td>
-          <td>
-            <a href="{% url 'admin:payments_payment_change' object_id=payment.pk %}">Edit</a>
-          </td>
-        </tr>
-      {% endfor %}
-    </table>
+    <section class="crm-section content">
+      {% translate "Actions" as section_title %}
+      {% include "crm/snippets/section_header.html" %}
+      <div class="crm-form-grid">
+        <form class="crm-form-panel crm-form-panel--balanced"
+              action="{% url "crm:customer-merge" pk=object.pk %}"
+              method="get">
+          <h3>{% translate "Merge customer" %}</h3>
+          <div class="crm-form-panel__body">
+            <div class="crm-field">
+              {{ merge_form.merge.label_tag }}
+              {{ merge_form.merge }}
+            </div>
+          </div>
+          <div class="crm-form-panel__actions">
+            {% translate "Review merge" as review_merge_label %}
+            <input class="crm-button" type="submit" value="{{ review_merge_label }}">
+          </div>
+        </form>
 
-  </section>
+        {% if can_add_customer_user %}
+          <form class="crm-form-panel crm-form-panel--balanced" method="post">
+            <h3>{% translate "Add user to customer" %}</h3>
+            {% csrf_token %}
+            <div class="crm-form-panel__body">{{ customer_user_form }}</div>
+            <div class="crm-form-panel__actions">
+              <input class="crm-button"
+                     type="submit"
+                     name="add_customer_user"
+                     value="{% translate "Add user" %}">
+            </div>
+          </form>
+        {% endif %}
 
+        <form class="crm-form-panel crm-form-panel--balanced" method="post">
+          <h3>{% translate "Add note" %}</h3>
+          {% csrf_token %}
+          <div class="crm-form-panel__body">
+            {{ manual_interaction_form.non_field_errors }}
+            <div class="crm-field crm-field--fill">
+              {{ manual_interaction_form.note.errors }}
+              {{ manual_interaction_form.note.label_tag }}
+              {{ manual_interaction_form.note }}
+            </div>
+          </div>
+          <div class="crm-form-panel__actions">
+            <input class="crm-button"
+                   type="submit"
+                   name="add_manual_note"
+                   value="{% translate "Add note" %}">
+          </div>
+        </form>
+      </div>
+    </section>
+
+    <section class="crm-section content">
+      {% translate "Customer services" as section_title %}
+      {% include "crm/snippets/section_header.html" with section_title=section_title only %}
+      {% if services %}
+        <div class="crm-table-wrap">
+          <table class="crm-table">
+            {% include "crm/snippets/table_caption.html" with table_title=section_title only %}
+            <thead>
+              <tr>
+                <th scope="col">{% translate "Service" %}</th>
+                <th scope="col">{% translate "Customer" %}</th>
+                <th scope="col">{% translate "URL" %}</th>
+                <th scope="col">{% translate "Version" %}</th>
+                <th scope="col">{% translate "Status" %}</th>
+                <th scope="col">{% translate "Packages" %}</th>
+                <th scope="col">{% translate "Actions" %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% include "weblate_web/service_list_content.html" with object_list=services %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <form class="crm-form-panel crm-form-panel--balanced crm-form-panel--compact"
+              method="post">
+          <h3>{% translate "Invoice new service" %}</h3>
+          {% csrf_token %}
+          <div class="crm-form-panel__body">{{ new_subscription_form }}</div>
+          <div class="crm-form-panel__actions">
+            {% translate "Create" as create_label %}
+            <input class="crm-button" type="submit" value="{{ create_label }}">
+          </div>
+        </form>
+      {% endif %}
+    </section>
+
+    <section class="crm-section content">
+      {% translate "Agreements" as section_title %}
+      {% include "crm/snippets/section_header.html" with section_title=section_title only %}
+      {% if object.agreement_set.order %}
+        <div class="crm-table-wrap">
+          <table class="crm-table">
+            {% translate "Signed agreements" as table_title %}
+            {% include "crm/snippets/table_caption.html" with table_title=table_title only %}
+            <thead>
+              <tr>
+                <th scope="col">{% translate "Signed" %}</th>
+                <th scope="col">{% translate "Kind" %}</th>
+                <th scope="col">{% translate "Actions" %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for agreement in object.agreement_set.order %}
+                <tr>
+                  <td>{{ agreement.signed }}</td>
+                  <td>{{ agreement.get_kind_display }}</td>
+                  <td>
+                    <div class="crm-row-actions">
+                      <a href="{% url "agreement-download" pk=agreement.pk %}">{% translate "Download" %}</a>
+                    </div>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        {% translate "No agreements recorded." as empty_message %}
+        {% include "crm/snippets/empty.html" %}
+      {% endif %}
+      {% if perms.legal.add_agreement %}
+        <div class="crm-section-footer">
+          <a class="crm-button crm-button--secondary"
+             href="{% url "admin:legal_agreement_add" %}?customer={{ object.pk }}">{% translate "Add new agreement" %}</a>
+        </div>
+      {% endif %}
+    </section>
+
+    <section class="crm-section content">
+      {% translate "Donations" as section_title %}
+      {% include "crm/snippets/section_header.html" with section_title=section_title only %}
+      {% if donations %}
+        <div class="crm-table-wrap">
+          <table class="crm-table">
+            {% translate "Donation history" as table_title %}
+            {% include "crm/snippets/table_caption.html" with table_title=table_title only %}
+            <thead>
+              <tr>
+                <th scope="col">{% translate "Created" %}</th>
+                <th scope="col">{% translate "Reward" %}</th>
+                <th scope="col">{% translate "Amount" %}</th>
+                <th scope="col">{% translate "Actions" %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for donation in donations %}
+                <tr>
+                  <td>{{ donation.created }}</td>
+                  <td>{{ donation.donation_subscription.package.donation_reward_display }}</td>
+                  <td>{{ donation.get_donation_amount }} EUR</td>
+                  <td>
+                    <div class="crm-row-actions">
+                      <a href="{% url "admin:weblate_web_service_change" object_id=donation.pk %}">{% translate "Edit" %}</a>
+                    </div>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        {% translate "No donations recorded." as empty_message %}
+        {% include "crm/snippets/empty.html" %}
+      {% endif %}
+    </section>
+  {% endif %}
+
+  {% if active_tab == "invoices" %}
+    <section class="crm-section content">
+      {% translate "Invoice history" as section_title %}
+      {% include "crm/snippets/section_header.html" with section_title=section_title only %}
+      {% with invoices=object.invoice_set.order %}
+        {% if invoices %}
+          <div class="crm-table-wrap">
+            <table class="crm-table">
+              {% include "crm/snippets/table_caption.html" with table_title=section_title only %}
+              <thead>
+                <tr>
+                  <th scope="col">{% translate "Number" %}</th>
+                  <th scope="col">{% translate "Status" %}</th>
+                  <th scope="col">{% translate "Kind" %}</th>
+                  <th scope="col" class="crm-number">{% translate "Amount" %}</th>
+                  <th scope="col">{% translate "Description" %}</th>
+                  <th scope="col">{% translate "Customer" %}</th>
+                  <th scope="col">{% translate "Actions" %}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% include "invoices/invoice_list_content.html" with object_list=invoices %}
+              </tbody>
+            </table>
+          </div>
+        {% else %}
+          {% translate "No invoices recorded." as empty_message %}
+          {% include "crm/snippets/empty.html" %}
+        {% endif %}
+      {% endwith %}
+      {% if perms.invoices.add_invoice %}
+        <div class="crm-section-footer">
+          <a class="crm-button crm-button--secondary"
+             href="{% url "admin:invoices_invoice_add" %}?customer={{ object.pk }}">{% translate "Issue new invoice" %}</a>
+        </div>
+      {% endif %}
+    </section>
+  {% endif %}
+
+  {% if active_tab == "interactions" %}
+    <section class="crm-section content">
+      {% translate "Interaction history" as section_title %}
+      {% include "crm/snippets/section_header.html" with section_title=section_title only %}
+      {% if object.interaction_set.order %}
+        <div class="crm-table-wrap">
+          <table class="crm-table">
+            {% include "crm/snippets/table_caption.html" with table_title=section_title only %}
+            <thead>
+              <tr>
+                <th scope="col">{% translate "Timestamp" %}</th>
+                <th scope="col">{% translate "User" %}</th>
+                <th scope="col">{% translate "Origin" %}</th>
+                <th scope="col">{% translate "Summary" %}</th>
+                <th scope="col">{% translate "Content" %}</th>
+                <th scope="col">{% translate "Actions" %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for interaction in object.interaction_set.order %}
+                <tr>
+                  <td>{{ interaction.timestamp }}</td>
+                  <td>{{ interaction.user.username }}</td>
+                  <td>{{ interaction.get_origin_display }}</td>
+                  <td>{{ interaction.summary }}</td>
+                  <td>
+                    {% with primary=interaction.primary_content %}
+                      {% if primary and primary != interaction.summary %}{{ primary|linebreaksbr }}{% endif %}
+                    {% endwith %}
+                  </td>
+                  <td>
+                    <div class="crm-row-actions">
+                      {% if interaction.has_detail_page %}
+                        <a href="{% url "crm:interaction-detail" pk=interaction.pk %}" target="_blank">{% translate "View" %}</a>
+                      {% endif %}
+                      {% if interaction.attachment %}
+                        <a href="{{ interaction.attachment_download_url }}">{% translate "Download" %}</a>
+                      {% endif %}
+                    </div>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        {% translate "No interactions recorded." as empty_message %}
+        {% include "crm/snippets/empty.html" %}
+      {% endif %}
+    </section>
+  {% endif %}
+
+  {% if active_tab == "payments" %}
+    <section class="crm-section content">
+      {% translate "Payment history" as section_title %}
+      {% include "crm/snippets/section_header.html" with section_title=section_title only %}
+      {% if object.payment_set.order %}
+        <div class="crm-table-wrap">
+          <table class="crm-table">
+            {% include "crm/snippets/table_caption.html" with table_title=section_title only %}
+            <thead>
+              <tr>
+                <th scope="col">{% translate "Created" %}</th>
+                <th scope="col">{% translate "State" %}</th>
+                <th scope="col">{% translate "Amount" %}</th>
+                <th scope="col">{% translate "Description" %}</th>
+                <th scope="col">{% translate "Actions" %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for payment in object.payment_set.order %}
+                <tr>
+                  <td>{{ payment.created }}</td>
+                  <td>{{ payment.get_state_display }}</td>
+                  <td>{{ payment.get_amount_display }} {{ payment.get_currency_display }}</td>
+                  <td>{{ payment.description }}</td>
+                  <td>
+                    <div class="crm-row-actions">
+                      <a href="{% url "admin:payments_payment_change" object_id=payment.pk %}">{% translate "Edit" %}</a>
+                    </div>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        {% translate "No payments recorded." as empty_message %}
+        {% include "crm/snippets/empty.html" %}
+      {% endif %}
+    </section>
+  {% endif %}
 {% endblock content %}

--- a/weblate_web/crm/templates/payments/customer_list.html
+++ b/weblate_web/crm/templates/payments/customer_list.html
@@ -1,30 +1,54 @@
 {% extends "crm/base.html" %}
 
-{% load i18n static %}
+{% load i18n %}
 
 {% block content %}
-  <form>
-    {{ search_form.q.label_tag }}
-    {{ search_form.q }}
-    {% translate "Search" as search_label %}
-    <input type="submit" value="{{ search_label }}">
-  </form>
-  <section class="content">
-    <table>
-      {% for object in object_list %}
-        <tr>
-          <th>{{ object.name }}</th>
-          <th>{{ object.end_client }}</th>
-          <th>{{ object.email }}</th>
-          <td>{{ object.vat }}</td>
-          <td>{{ object.city }}</td>
-          <td>{{ object.get_country_display }}</td>
-          <td>
-            <a href="{{ object.get_absolute_url }}">Details</a>
-          </td>
-        </tr>
-      {% endfor %}
-    </table>
+  {% include "crm/snippets/search_form.html" %}
+
+  <section class="crm-section">
+    {% translate "Customer list" as table_title %}
+    {% include "crm/snippets/section_header.html" with section_title=table_title only %}
+    {% if object_list %}
+      <div class="crm-table-wrap">
+        <table class="crm-table">
+          {% include "crm/snippets/table_caption.html" with table_title=table_title only %}
+          <thead>
+            <tr>
+              <th scope="col">{% translate "Customer" %}</th>
+              <th scope="col">{% translate "End client" %}</th>
+              <th scope="col">{% translate "E-mail" %}</th>
+              <th scope="col">{% translate "VAT" %}</th>
+              <th scope="col">{% translate "City" %}</th>
+              <th scope="col">{% translate "Country" %}</th>
+              <th scope="col">{% translate "Actions" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for object in object_list %}
+              <tr>
+                <th scope="row">
+                  <a href="{{ object.get_absolute_url }}">{{ object.name }}</a>
+                </th>
+                <td>{{ object.end_client|default:"-" }}</td>
+                <td>{{ object.email|default:"-" }}</td>
+                <td>{{ object.vat|default:"-" }}</td>
+                <td>{{ object.city|default:"-" }}</td>
+                <td>{{ object.get_country_display|default:"-" }}</td>
+                <td>
+                  <div class="crm-row-actions">
+                    <a href="{{ object.get_absolute_url }}">{% translate "Details" %}</a>
+                  </div>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% else %}
+      {% translate "No customers match the current filters." as empty_message %}
+      {% include "crm/snippets/empty.html" %}
+    {% endif %}
   </section>
+
   {% include "crm/pagination.html" %}
 {% endblock content %}

--- a/weblate_web/crm/templates/payments/customer_merge.html
+++ b/weblate_web/crm/templates/payments/customer_merge.html
@@ -1,37 +1,41 @@
 {% extends "crm/base.html" %}
 
-{% load i18n static timestamps %}
+{% load i18n %}
 
 {% block breadcrum_list %}
-  › <a href="{% url "crm:customer-list" kind="all" %}">Customers</a>
+  <span aria-hidden="true">›</span>
+  <a href="{% url "crm:customer-list" kind="all" %}">{% translate "Customers" %}</a>
 {% endblock breadcrum_list %}
 
 {% block content %}
-  <section class="content">
-    <p>
-      <a href="{{ object.get_absolute_url }}">{{ object.name }} ({{ object.pk }})</a>
-      {% translate "will be merged into" %}
-      <a href="{{ merge.get_absolute_url }}">{{ merge.name }} ({{ merge.pk }})</a>.
-    </p>
-    <ul>
-      <li>
-        {% blocktranslate with source=object.name source_pk=object.pk target=merge.name target_pk=merge.pk trimmed %}
-          All content from {{ source }} ({{ source_pk }}) will be moved to {{ target }} ({{ target_pk }})
-        {% endblocktranslate %}
-      </li>
-      <li>
-        {% blocktranslate with source=object.name source_pk=object.pk trimmed %}
-          {{ source }} ({{ source_pk }}) will be removed
-        {% endblocktranslate %}
-      </li>
-    </ul>
-    <form method="post">
+  <section class="crm-section content">
+    {% translate "Review merge" as section_title %}
+    {% include "crm/snippets/section_header.html" %}
+    <div class="crm-warning">
+      <p>
+        <a href="{{ object.get_absolute_url }}">{{ object.name }} ({{ object.pk }})</a>
+        {% translate "will be merged into" %}
+        <a href="{{ merge.get_absolute_url }}">{{ merge.name }} ({{ merge.pk }})</a>.
+      </p>
+      <ul>
+        <li>
+          {% blocktranslate with source=object.name source_pk=object.pk target=merge.name target_pk=merge.pk trimmed %}
+            All content from {{ source }} ({{ source_pk }}) will be moved to {{ target }} ({{ target_pk }})
+          {% endblocktranslate %}
+        </li>
+        <li>
+          {% blocktranslate with source=object.name source_pk=object.pk trimmed %}
+            {{ source }} ({{ source_pk }}) will be removed
+          {% endblocktranslate %}
+        </li>
+      </ul>
+    </div>
+    <form class="crm-form-panel crm-form-panel--inline" method="post">
       {% csrf_token %}
       {{ merge_form.merge }}
       {% translate "Merge" as merge_label %}
-      <input type="submit" value="{{ merge_label }}">
-      <a href="{{ object.get_absolute_url }}">{% translate "Cancel" %}</a>
+      <input class="crm-button crm-button--danger" type="submit" value="{{ merge_label }}">
+      <a class="crm-button crm-button--secondary" href="{{ object.get_absolute_url }}">{% translate "Cancel" %}</a>
     </form>
   </section>
-
 {% endblock content %}

--- a/weblate_web/crm/templates/weblate_web/service_detail.html
+++ b/weblate_web/crm/templates/weblate_web/service_detail.html
@@ -1,167 +1,298 @@
 {% extends "crm/base.html" %}
 
-{% load i18n static %}
+{% load i18n %}
 
 {% block breadcrum_list %}
-  › <a href="{% url "crm:service-list" kind="all" %}">Services</a>
+  <span aria-hidden="true">›</span>
+  <a href="{% url "crm:service-list" kind="all" %}">{% translate "Services" %}</a>
 {% endblock breadcrum_list %}
 
+{% block page_actions %}
+  <div class="crm-page-actions">
+    <a class="crm-button crm-button--secondary"
+       href="{% url "admin:weblate_web_service_change" object_id=object.pk %}">{% translate "Edit in admin" %}</a>
+  </div>
+{% endblock page_actions %}
+
 {% block content %}
-  <section class="content">
-    <h2>{{ object.site_title }}</h2>
-    <p>
-      <a href="{% url 'crm:customer-detail' pk=object.customer.pk %}">{{ object.customer.verbose_name }}</a>
-      <br>
-      <a href="{{ object.site_url }}">{{ object.site_url }}</a>
-      {% if object.site_url_lock %}<strong>locked</strong>{% endif %}
-      <br>
-      Weblate {{ object.site_version }}, {{ object.site_users }} users, {{ object.site_projects }} projects
-      <br>
-      Support status: {{ object.get_status_display }}
-    </br>
-    {% if object.secret %}
-      Activation key: {{ object.secret }}
-    </br>
-  {% endif %}
-  {% if object.backup_repository %}
-    Backup: {{ object.backup_repository }} ({{ object.backup_size|filesizeformat }} in {{ object.backup_directory }})
-    <br>
-  {% endif %}
-  {% if object.discoverable %}
-    Discoverable: {{ object.discover_text }}
-    <br>
-    {% if object.discover_image %}
-      <img class="discover-img" src="{{ object.discover_image.url }}" />
-      <br>
+  <section class="crm-section content">
+    {% translate "Service" as section_title %}
+    {% include "crm/snippets/section_header.html" %}
+    <dl class="crm-detail-grid">
+      <div>
+        <dt>{% translate "Customer" %}</dt>
+        <dd>
+          <a href="{% url "crm:customer-detail" pk=object.customer.pk %}">{{ object.customer.verbose_name }}</a>
+        </dd>
+      </div>
+      <div>
+        <dt>{% translate "URL" %}</dt>
+        <dd>
+          <a href="{{ object.site_url }}">{{ object.site_url }}</a>
+          {% if object.site_url_lock %}
+            <strong>{% translate "locked" %}</strong>
+          {% endif %}
+        </dd>
+      </div>
+      <div>
+        <dt>{% translate "Weblate" %}</dt>
+        <dd>
+          {{ object.site_version }}
+        </dd>
+      </div>
+      <div>
+        <dt>{% translate "Users" %}</dt>
+        <dd>
+          {{ object.site_users }}
+        </dd>
+      </div>
+      <div>
+        <dt>{% translate "Projects" %}</dt>
+        <dd>
+          {{ object.site_projects }}
+        </dd>
+      </div>
+      <div>
+        <dt>{% translate "Support status" %}</dt>
+        <dd>
+          {{ object.get_status_display }}
+        </dd>
+      </div>
+      {% if object.secret %}
+        <div class="crm-detail-grid__wide">
+          <dt>{% translate "Activation key" %}</dt>
+          <dd>
+            <code class="crm-activation-key">{{ object.secret }}</code>
+          </dd>
+        </div>
+      {% endif %}
+      {% if object.backup_repository %}
+        <div>
+          <dt>{% translate "Backup" %}</dt>
+          <dd>
+            {{ object.backup_repository }}
+            <span class="crm-muted">
+              {% blocktranslate with size=object.backup_size|filesizeformat directory=object.backup_directory %}{{ size }} in {{ directory }}{% endblocktranslate %}
+            </span>
+          </dd>
+        </div>
+      {% endif %}
+      {% if object.discoverable %}
+        <div>
+          <dt>{% translate "Discoverable" %}</dt>
+          <dd>
+            {{ object.discover_text }}
+          </dd>
+        </div>
+      {% endif %}
+    </dl>
+    {% if object.discoverable and object.discover_image %}
+      <div class="crm-media">
+        <img class="discover-img" src="{{ object.discover_image.url }}" alt="">
+      </div>
     {% endif %}
+  </section>
+
+  {% if maintenance_window_form %}
+    <section class="crm-section content">
+      {% translate "Maintenance window" as section_title %}
+      {% include "crm/snippets/section_header.html" %}
+      <form class="crm-form-panel crm-form-panel--compact" method="post">
+        {% csrf_token %}
+        <div class="crm-form-panel__body">{{ maintenance_window_form }}</div>
+        <div class="crm-form-panel__actions">
+          <input class="crm-button"
+                 type="submit"
+                 name="update_maintenance_window"
+                 value="{% translate "Update maintenance window" %}">
+        </div>
+      </form>
+    </section>
   {% endif %}
-  <a href="{% url "admin:weblate_web_service_change" object_id=object.pk %}">Edit</a>
-</p>
-{% if maintenance_window_form %}
-  <h2>{% translate "Maintenance window" %}</h2>
-  <form method="post">
-    {% csrf_token %}
-    {{ maintenance_window_form }}
-    <input type="submit"
-           name="update_maintenance_window"
-           value="{% translate "Update maintenance window" %}">
-  </form>
-{% endif %}
-{% for subscription in object.subscription_set.all %}
-  <h2>{{ subscription.package }}</h2>
-  <p>
-    {% if not subscription.enabled %}
-      <strong>Service is terminated</strong>
-      <br>
-    {% endif %}
-    Expires: {{ subscription.expires }}
-    <br>
-    <form method="post">
-      {% csrf_token %}
-      {{ reference_form }}
-      <input type="hidden" name="subscription" value="{{ subscription.pk }}">
-      <input type="submit" name="quote" value="{% translate "Issue renewal quote" %}">
-    </form>
-    <details class="crm-danger-action">
-      <summary>{% translate "Issue renewal invoice" %}</summary>
-      <p>
-        {% blocktranslate %}This creates a final invoice for the renewal. Use the renewal quote action if you only need a quote.{% endblocktranslate %}
-      </p>
-      <form method="post">
-        {% csrf_token %}
-        {{ reference_form }}
-        <input type="hidden" name="subscription" value="{{ subscription.pk }}">
-        <input type="hidden" name="invoice" value="1">
-        <label>
-          <input type="checkbox" name="confirm_invoice" value="1" required>
-          {% translate "I confirm that I want to issue a final invoice." %}
-        </label>
-        <br>
-        <input type="submit" value="{% translate "Issue renewal invoice" %}">
-      </form>
-    </details>
 
-    {% for package in subscription.upgrade_packages %}
-      <br>
-      {% blocktranslate %}Upgrade to {{ package }} without extending the current subscription period.{% endblocktranslate %}
-      <form method="post">
-        {% csrf_token %}
-        {{ reference_form }}
-        <input type="hidden" name="subscription" value="{{ subscription.pk }}">
-        <input type="hidden" name="package" value="{{ package.name }}">
-        <input type="submit"
-               name="upgrade_quote"
-               value="{% translate "Issue upgrade quote" %}">
-      </form>
-      <details class="crm-danger-action">
-        <summary>{% translate "Issue upgrade invoice" %}</summary>
-        <p>
-          {% blocktranslate %}This creates a final invoice for the upgrade. Use the upgrade quote action if you only need a quote.{% endblocktranslate %}
-        </p>
-        <form method="post">
-          {% csrf_token %}
-          {{ reference_form }}
-          <input type="hidden" name="subscription" value="{{ subscription.pk }}">
-          <input type="hidden" name="package" value="{{ package.name }}">
-          <input type="hidden" name="upgrade_invoice" value="1">
-          <label>
-            <input type="checkbox" name="confirm_invoice" value="1" required>
-            {% translate "I confirm that I want to issue a final invoice." %}
-          </label>
-          <br>
-          <input type="submit" value="{% translate "Issue upgrade invoice" %}">
-        </form>
-      </details>
-    {% endfor %}
+  {% for subscription in object.subscription_set.all %}
+    <section class="crm-section content">
+      {% include "crm/snippets/section_header.html" with section_title=subscription.package %}
+      <div class="crm-subscription-summary">
+        <dl class="crm-detail-grid crm-detail-grid--compact">
+          <div>
+            <dt>{% translate "Status" %}</dt>
+            <dd>
+              {% if subscription.enabled %}
+                <span class="crm-badge crm-badge--success">{% translate "Active" %}</span>
+              {% else %}
+                <strong>{% translate "Service is terminated" %}</strong>
+              {% endif %}
+            </dd>
+          </div>
+          <div>
+            <dt>{% translate "Expires" %}</dt>
+            <dd>
+              {{ subscription.expires }}
+            </dd>
+          </div>
+        </dl>
+        <div class="crm-row-actions">
+          <a href="{% url "admin:weblate_web_subscription_change" object_id=subscription.pk %}">{% translate "Edit subscription in admin" %}</a>
+        </div>
+      </div>
 
-    {% if subscription.enabled %}
-      <br>
-      <form method="post">
-        {% csrf_token %}
-        <input type="hidden" name="subscription" value="{{ subscription.pk }}">
-        <label>
-          <input type="checkbox" required>
-          Disable the subscription, no payments will be reminded or triggered, <strong>backups will be removed once subscription expires</strong>
-        </label>
-        <br>
-        <input type="submit" name="disable" value="Disable">
-      </form>
-    {% endif %}
-    <a href="{% url "admin:weblate_web_subscription_change" object_id=subscription.pk %}">Edit</a>
-  </p>
-{% endfor %}
+      <div class="crm-action-group">
+        <h3>{% translate "Renewal" %}</h3>
+        <div class="crm-form-grid">
+          <form class="crm-form-panel crm-form-panel--balanced" method="post">
+            <h3>{% translate "Renewal quote" %}</h3>
+            {% csrf_token %}
+            <div class="crm-form-panel__body">
+              {{ reference_form }}
+              <input type="hidden" name="subscription" value="{{ subscription.pk }}">
+            </div>
+            <div class="crm-form-panel__actions">
+              <input class="crm-button"
+                     type="submit"
+                     name="quote"
+                     value="{% translate "Issue renewal quote" %}">
+            </div>
+          </form>
 
-{% if object.recent_reports %}
-  <h2>Recent reports</h2>
-  <table>
-    <thead>
-      <tr>
-        <th>Timestamp</th>
-        <th>Site URL</th>
-        <th>Site title</th>
-        <th>Weblate version</th>
-        <th>Users</th>
-        <th>Projects</th>
-        <th>Hosted strings</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for report in object.recent_reports %}
-        <tr>
-          <td>{{ report.timestamp }}</td>
-          <td>
-            <a href="{{ report.site_url }}">{{ report.site_url }}</a>
-          </td>
-          <td>{{ report.site_title }}</td>
-          <td>{{ report.version }}</td>
-          <td>{{ report.users }}</td>
-          <td>{{ report.projects }}</td>
-          <td>{{ report.hosted_strings }}</td>
-        </tr>
+          <details class="crm-danger-action">
+            <summary>{% translate "Issue renewal invoice" %}</summary>
+            <p>
+              {% blocktranslate %}This creates a final invoice for the renewal. Use the renewal quote action if you only need a quote.{% endblocktranslate %}
+            </p>
+            <form class="crm-form-panel crm-form-panel--compact" method="post">
+              {% csrf_token %}
+              <div class="crm-form-panel__body">
+                {{ reference_form }}
+                <input type="hidden" name="subscription" value="{{ subscription.pk }}">
+                <input type="hidden" name="invoice" value="1">
+                <label class="crm-check">
+                  <input type="checkbox" name="confirm_invoice" value="1" required>
+                  <span>{% translate "I confirm that I want to issue a final invoice." %}</span>
+                </label>
+              </div>
+              <div class="crm-form-panel__actions">
+                <input class="crm-button"
+                       type="submit"
+                       value="{% translate "Issue renewal invoice" %}">
+              </div>
+            </form>
+          </details>
+        </div>
+      </div>
+
+      {% for package in subscription.upgrade_packages %}
+        <div class="crm-action-group">
+          <h3>{% translate "Upgrade" %}</h3>
+          <p>
+            {% blocktranslate %}Upgrade to {{ package }} without extending the current subscription period.{% endblocktranslate %}
+          </p>
+          <div class="crm-form-grid">
+            <form class="crm-form-panel crm-form-panel--balanced" method="post">
+              <h3>{% translate "Upgrade quote" %}</h3>
+              {% csrf_token %}
+              <div class="crm-form-panel__body">
+                {{ reference_form }}
+                <input type="hidden" name="subscription" value="{{ subscription.pk }}">
+                <input type="hidden" name="package" value="{{ package.name }}">
+              </div>
+              <div class="crm-form-panel__actions">
+                <input class="crm-button"
+                       type="submit"
+                       name="upgrade_quote"
+                       value="{% translate "Issue upgrade quote" %}">
+              </div>
+            </form>
+            <details class="crm-danger-action">
+              <summary>{% translate "Issue upgrade invoice" %}</summary>
+              <p>
+                {% blocktranslate %}This creates a final invoice for the upgrade. Use the upgrade quote action if you only need a quote.{% endblocktranslate %}
+              </p>
+              <form class="crm-form-panel crm-form-panel--compact" method="post">
+                {% csrf_token %}
+                <div class="crm-form-panel__body">
+                  {{ reference_form }}
+                  <input type="hidden" name="subscription" value="{{ subscription.pk }}">
+                  <input type="hidden" name="package" value="{{ package.name }}">
+                  <input type="hidden" name="upgrade_invoice" value="1">
+                  <label class="crm-check">
+                    <input type="checkbox" name="confirm_invoice" value="1" required>
+                    <span>{% translate "I confirm that I want to issue a final invoice." %}</span>
+                  </label>
+                </div>
+                <div class="crm-form-panel__actions">
+                  <input class="crm-button"
+                         type="submit"
+                         value="{% translate "Issue upgrade invoice" %}">
+                </div>
+              </form>
+            </details>
+          </div>
+        </div>
       {% endfor %}
-    </tbody>
-  </table>
-{% endif %}
 
-</section>
+      {% if subscription.enabled %}
+        <div class="crm-action-group">
+          <form class="crm-form-panel crm-form-panel--balanced crm-form-panel--danger"
+                method="post">
+            <h3>{% translate "Disable subscription" %}</h3>
+            {% csrf_token %}
+            <div class="crm-form-panel__body">
+              <input type="hidden" name="subscription" value="{{ subscription.pk }}">
+              <label class="crm-check">
+                <input type="checkbox" required>
+                <span>
+                  {% blocktranslate %}Disable the subscription, no payments will be reminded or triggered, <strong>backups will be removed once subscription expires</strong>{% endblocktranslate %}
+                </span>
+              </label>
+            </div>
+            <div class="crm-form-panel__actions">
+              <input class="crm-button crm-button--danger"
+                     type="submit"
+                     name="disable"
+                     value="{% translate "Disable" %}">
+            </div>
+          </form>
+        </div>
+      {% endif %}
+    </section>
+  {% endfor %}
+
+  {% if object.recent_reports %}
+    <section class="crm-section content">
+      {% translate "Recent service reports" as table_title %}
+      {% include "crm/snippets/section_header.html" with section_title=table_title only %}
+      <div class="crm-table-wrap">
+        <table class="crm-table">
+          {% include "crm/snippets/table_caption.html" with table_title=table_title only %}
+          <thead>
+            <tr>
+              <th scope="col">{% translate "Timestamp" %}</th>
+              <th scope="col">{% translate "Site URL" %}</th>
+              <th scope="col">{% translate "Site title" %}</th>
+              <th scope="col">{% translate "Weblate version" %}</th>
+              <th scope="col" class="crm-number">{% translate "Users" %}</th>
+              <th scope="col" class="crm-number">{% translate "Projects" %}</th>
+              <th scope="col" class="crm-number">{% translate "Hosted strings" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for report in object.recent_reports %}
+              <tr>
+                <td>{{ report.timestamp }}</td>
+                <td>
+                  <a href="{{ report.site_url }}">{{ report.site_url }}</a>
+                </td>
+                <td>{{ report.site_title }}</td>
+                <td>{{ report.version }}</td>
+                <td class="crm-number">{{ report.users }}</td>
+                <td class="crm-number">{{ report.projects }}</td>
+                <td class="crm-number">{{ report.hosted_strings }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  {% endif %}
 {% endblock content %}

--- a/weblate_web/crm/templates/weblate_web/service_list.html
+++ b/weblate_web/crm/templates/weblate_web/service_list.html
@@ -1,21 +1,78 @@
 {% extends "crm/base.html" %}
 
-{% load i18n static %}
+{% load i18n %}
+
+{% block page_header %}
+  {% if kind == "all" %}
+    <h1 class="crm-sr-only">{{ title|default:"CRM" }}</h1>
+  {% else %}
+    {{ block.super }}
+  {% endif %}
+{% endblock page_header %}
 
 {% block content %}
-  {% if kind == "expired" or kind == "all" %}
-    {% regroup object_list by package_kind as service_list %}
+  {% if object_list %}
+    {% if kind == "expired" or kind == "all" %}
+      {% regroup object_list by package_kind as service_list %}
 
-    {% for package_group in service_list %}
-      <h3>{{ package_group.grouper }}</h3>
-      <section class="content">
-        {% include "weblate_web/service_list_content.html" with object_list=package_group.list %}
+      {% for package_group in service_list %}
+        <section class="crm-section">
+          {% include "crm/snippets/section_header.html" with section_title=package_group.grouper only %}
+          <div class="crm-table-wrap">
+            <table class="crm-table">
+              {% include "crm/snippets/table_caption.html" with table_title=package_group.grouper only %}
+              <thead>
+                <tr>
+                  <th scope="col">{% translate "Service" %}</th>
+                  <th scope="col">{% translate "Customer" %}</th>
+                  <th scope="col">{% translate "URL" %}</th>
+                  <th scope="col">{% translate "Version" %}</th>
+                  <th scope="col">{% translate "Status" %}</th>
+                  <th scope="col">{% translate "Packages" %}</th>
+                  <th scope="col">{% translate "Actions" %}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% include "weblate_web/service_list_content.html" with object_list=package_group.list %}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      {% endfor %}
+    {% else %}
+      <section class="crm-section">
+        {% translate "Services" as table_title %}
+        {% include "crm/snippets/section_header.html" with section_title=table_title only %}
+        <div class="crm-table-wrap">
+          <table class="crm-table">
+            {% include "crm/snippets/table_caption.html" with table_title=table_title only %}
+            <thead>
+              <tr>
+                <th scope="col">{% translate "Service" %}</th>
+                <th scope="col">{% translate "Customer" %}</th>
+                <th scope="col">{% translate "URL" %}</th>
+                <th scope="col">{% translate "Version" %}</th>
+                <th scope="col">{% translate "Status" %}</th>
+                {% if kind == "extended" %}
+                  <th scope="col">{% translate "Maintenance" %}</th>
+                {% endif %}
+                <th scope="col">{% translate "Packages" %}</th>
+                <th scope="col">{% translate "Actions" %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% include "weblate_web/service_list_content.html" %}
+            </tbody>
+          </table>
+        </div>
       </section>
-    {% endfor %}
-
+    {% endif %}
   {% else %}
-    <section class="content">
-      {% include "weblate_web/service_list_content.html" %}
+    <section class="crm-section">
+      {% translate "Services" as section_title %}
+      {% include "crm/snippets/section_header.html" with section_title=section_title only %}
+      {% translate "No services match the current filters." as empty_message %}
+      {% include "crm/snippets/empty.html" %}
     </section>
   {% endif %}
 {% endblock content %}

--- a/weblate_web/crm/templates/weblate_web/service_list_content.html
+++ b/weblate_web/crm/templates/weblate_web/service_list_content.html
@@ -1,25 +1,32 @@
-<table>
-  {% for object in object_list %}
-    <tr>
-      <th>{{ object.site_title }}</th>
-      <td>
-        <a href="{% url 'crm:customer-detail' pk=object.customer.pk %}">{{ object.customer.verbose_name }}</a>
-      </td>
-      <td>
-        <a href="{{ object.site_url }}">{{ object.site_url }}</a>
-      </td>
-      <td>{{ object.site_version }}</td>
-      <td>{{ object.get_status_display }}</td>
-      {% if kind == "extended" %}<td>{{ object.maintenance_window|default:"-" }}</td>{% endif %}
-      <td>
-        {% for subscription in object.enabled_subscriptions %}
-          {{ subscription.package }}
-          {% if not forloop.last %}<br>{% endif %}
-        {% endfor %}
-      </td>
-      <td>
-        <a href="{{ object.get_absolute_url }}">Details</a>
-      </td>
-    </tr>
-  {% endfor %}
-</table>
+{% load i18n %}
+
+{% for object in object_list %}
+  <tr>
+    <th scope="row">
+      <a href="{{ object.get_absolute_url }}">{{ object.site_title }}</a>
+    </th>
+    <td>
+      <a href="{% url "crm:customer-detail" pk=object.customer.pk %}">{{ object.customer.verbose_name }}</a>
+    </td>
+    <td>
+      <a href="{{ object.site_url }}">{{ object.site_url }}</a>
+    </td>
+    <td>{{ object.site_version|default:"-" }}</td>
+    <td>
+      <span class="crm-badge">{{ object.get_status_display }}</span>
+    </td>
+    {% if kind == "extended" %}<td>{{ object.maintenance_window|default:"-" }}</td>{% endif %}
+    <td>
+      {% for subscription in object.enabled_subscriptions %}
+        <span class="crm-token">{{ subscription.package }}</span>
+      {% empty %}
+        <span class="crm-muted">-</span>
+      {% endfor %}
+    </td>
+    <td>
+      <div class="crm-row-actions">
+        <a href="{{ object.get_absolute_url }}">{% translate "Details" %}</a>
+      </div>
+    </td>
+  </tr>
+{% endfor %}

--- a/weblate_web/crm/tests.py
+++ b/weblate_web/crm/tests.py
@@ -385,8 +385,12 @@ class CRMTestCase(BaseCRMTestCase):
             list(customer.payment_set.order()),
             [alpha_payment, beta_payment],
         )
+        response = self.client.get(customer.get_absolute_url(), {"tab": "interactions"})
         content = response.content.decode()
         self.assertLess(content.index("Alpha note"), content.index("Beta note"))
+
+        response = self.client.get(customer.get_absolute_url(), {"tab": "payments"})
+        content = response.content.decode()
         self.assertLess(content.index("Alpha payment"), content.index("Beta payment"))
 
     def test_customer_detail_hides_add_customer_user_for_readonly_staff(self):
@@ -445,7 +449,10 @@ class CRMTestCase(BaseCRMTestCase):
             {"add_manual_note": "1", "note": note},
         )
 
-        self.assertRedirects(response, customer.get_absolute_url())
+        self.assertRedirects(
+            response,
+            f"{customer.get_absolute_url()}?tab=interactions",
+        )
         interaction = Interaction.objects.get(customer=customer)
         self.assertEqual(interaction.origin, Interaction.Origin.MANUAL_NOTE)
         self.assertEqual(interaction.user, self.user)
@@ -455,7 +462,7 @@ class CRMTestCase(BaseCRMTestCase):
         )
         self.assertEqual(interaction.content, note)
 
-        response = self.client.get(customer.get_absolute_url())
+        response = self.client.get(customer.get_absolute_url(), {"tab": "interactions"})
         self.assertContains(response, "Manual note")
         self.assertContains(
             response, "Updated the invoice with correct PO# and sent it to customer."
@@ -1296,7 +1303,9 @@ class CRMTestCase(BaseCRMTestCase):
         self.assertEqual(interaction.details["payment_id"], str(payment.pk))
         self.assertEqual(interaction.details["invoice"], invoice.number)
 
-        response = self.client.get(invoice.customer.get_absolute_url())
+        response = self.client.get(
+            invoice.customer.get_absolute_url(), {"tab": "interactions"}
+        )
         self.assertContains(response, description)
 
     @patch.object(Invoice, "generate_receipt")
@@ -1389,7 +1398,7 @@ class CRMTestCase(BaseCRMTestCase):
         self.assertContains(response, "billing@example.com")
         self.assertContains(response, "HTML body")
 
-    def test_customer_detail_keeps_interaction_details_on_detail_page(self):
+    def test_customer_detail_keeps_interaction_details_on_interactions_tab(self):
         customer = self.create_customer()
         interaction = customer.interaction_set.create(
             origin=Interaction.Origin.ZAMMAD_ATTACHMENT,
@@ -1405,7 +1414,7 @@ class CRMTestCase(BaseCRMTestCase):
         )
         interaction.attachment.save("contract.pdf", ContentFile(b"PDF content"))
 
-        response = self.client.get(customer.get_absolute_url())
+        response = self.client.get(customer.get_absolute_url(), {"tab": "interactions"})
 
         self.assertContains(response, "contract.pdf")
         self.assertNotContains(response, "Ticket ID")

--- a/weblate_web/crm/views.py
+++ b/weblate_web/crm/views.py
@@ -561,6 +561,15 @@ class CustomerDetailView(CRMMixin, DetailView[Customer]):  # type: ignore[misc]
     permission = "payments.view_customer"
     add_customer_user_permission = "payments.change_customer"
     title = "Customer detail"
+    valid_tabs: ClassVar[frozenset[str]] = frozenset(
+        {"overview", "interactions", "invoices", "payments"}
+    )
+
+    def get_active_tab(self) -> str:
+        tab = self.request.GET.get("tab", "overview")
+        if tab in self.valid_tabs:
+            return tab
+        return "overview"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)  # type:ignore[misc]
@@ -590,7 +599,12 @@ class CustomerDetailView(CRMMixin, DetailView[Customer]):  # type: ignore[misc]
         context["services"] = self.object.service_set.customer_services().order()
         context["donations"] = self.object.service_set.donations().order()
         context["customer_users"] = self.object.ordered_users
+        context["active_tab"] = self.get_active_tab()
         return context
+
+    @staticmethod
+    def get_tab_url(customer: Customer, tab: str) -> str:
+        return f"{customer.get_absolute_url()}?tab={tab}"
 
     @classmethod
     def check_add_customer_user_permission(
@@ -765,7 +779,7 @@ class CustomerDetailView(CRMMixin, DetailView[Customer]):  # type: ignore[misc]
                     content=note,
                     user=request.user,
                 )
-                return redirect(customer)
+                return redirect(self.get_tab_url(customer, "interactions"))
             return self.get(request, *args, **kwargs)
 
         subscription_form = NewSubscriptionForm(request.POST)
@@ -904,7 +918,11 @@ class IncomeView(CRMMixin, TemplateView):  # type: ignore[misc]
         non_zero_categories = [cat for cat, val in data.items() if val > 0]
 
         svg_parts = [
-            f'<svg width="{width}" height="{height}" xmlns="http://www.w3.org/2000/svg" class="pie-chart">',
+            (
+                f'<svg viewBox="0 0 {width} {height}" '
+                f'width="{width}" height="{height}" '
+                'xmlns="http://www.w3.org/2000/svg" class="pie-chart">'
+            ),
         ]
 
         # Special case: if only one category, draw a circle instead of a pie slice
@@ -1021,7 +1039,11 @@ class IncomeView(CRMMixin, TemplateView):  # type: ignore[misc]
             max_value = self.MIN_CHART_VALUE
 
         svg_parts = [
-            f'<svg width="{width}" height="{height}" xmlns="http://www.w3.org/2000/svg" class="stacked-bar-chart">',
+            (
+                f'<svg viewBox="0 0 {width} {height}" '
+                f'width="{width}" height="{height}" '
+                'xmlns="http://www.w3.org/2000/svg" class="stacked-bar-chart">'
+            ),
         ]
 
         # Calculate bar properties

--- a/weblate_web/tests_e2e/test_crm.py
+++ b/weblate_web/tests_e2e/test_crm.py
@@ -21,7 +21,6 @@
 
 from __future__ import annotations
 
-import re
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
@@ -381,6 +380,66 @@ def assert_text_visible(page: Page, text: str, *, exact: bool = True) -> None:
     assert page.get_by_text(text, exact=exact).first.is_visible()
 
 
+def assert_customer_tab_selected(page: Page, name: str) -> None:
+    """Assert a customer detail tab is selected in the tab navigation."""
+    tab = page.get_by_label("Customer sections").get_by_role(
+        "link", name=name, exact=True
+    )
+    assert tab.get_attribute("aria-current") == "page"
+    assert "is-active" in (tab.get_attribute("class") or "")
+
+
+def assert_no_horizontal_overflow(page: Page) -> None:
+    """Assert the document fits the current viewport horizontally."""
+    assert page.evaluate(
+        "() => document.documentElement.scrollWidth <= "
+        "document.documentElement.clientWidth + 1"
+    )
+
+
+def assert_income_charts_fit(page: Page) -> None:
+    """Assert generated income charts scale inside their panels."""
+    charts = page.locator(".crm-chart")
+    assert charts.count() == 2
+    for index in range(charts.count()):
+        assert charts.nth(index).evaluate(
+            """element => {
+                const svg = element.querySelector("svg");
+                if (!svg) {
+                    return false;
+                }
+                const chartRect = element.getBoundingClientRect();
+                const svgRect = svg.getBoundingClientRect();
+                return svgRect.width > 0
+                    && svgRect.width <= chartRect.width + 1
+                    && element.scrollWidth <= element.clientWidth + 1;
+            }"""
+        )
+
+
+def assert_section_table_does_not_scroll(page: Page, heading: str) -> None:
+    """Assert a section table is not wider than its wrapping panel."""
+    section = page.locator(
+        "section.crm-section",
+        has=page.get_by_role("heading", name=heading, exact=True),
+    )
+    assert section.locator(".crm-table-wrap").evaluate(
+        "element => element.scrollWidth <= element.clientWidth + 1"
+    )
+
+
+def assert_summary_chips_same_height(page: Page) -> None:
+    """Assert invoice summary chips share the same visual height."""
+    assert page.locator(".crm-summary-line > span").evaluate_all(
+        """elements => {
+            const heights = elements.map(
+                element => Math.round(element.getBoundingClientRect().height)
+            );
+            return Math.max(...heights) - Math.min(...heights) <= 1;
+        }"""
+    )
+
+
 def log_in(page: Page, live_server, user: User) -> None:
     """Log in through Django admin using the CRM staff user."""
     response = page.goto(f"{live_server.url}/admin/login/")
@@ -404,7 +463,19 @@ class TestCrmVisualCoverage:  # pylint: disable=redefined-outer-name
         response = page.goto(absolute_url(live_server, reverse("crm:index")))
         assert_loaded(page, response, "CRM dashboard")
         assert page.get_by_role("link", name="Customers", exact=True).is_visible()
+        assert (
+            page.locator(".crm-brand span").evaluate(
+                "element => getComputedStyle(element).color"
+            )
+            == "rgb(255, 255, 255)"
+        )
         capture(page, "dashboard")
+
+        page.locator(".crm-dashboard-item").filter(has_text="Active customers").click()
+        page.wait_for_load_state("networkidle")
+        assert page.url == absolute_url(
+            live_server, reverse("crm:customer-list", kwargs={"kind": "active"})
+        )
 
         for kind in ("all", "active"):
             response = page.goto(
@@ -435,6 +506,12 @@ class TestCrmVisualCoverage:  # pylint: disable=redefined-outer-name
             assert_loaded(page, response, f"Service list {kind}")
             capture(page, f"services-{kind}")
 
+        page.get_by_label("CRM navigation").get_by_role("link", name="Invoices").click()
+        page.wait_for_load_state("networkidle")
+        assert page.url == absolute_url(
+            live_server, reverse("crm:invoice-list", kwargs={"kind": "invoice"})
+        )
+
         for kind in ("all", "invoice", "quote", "unpaid"):
             response = page.goto(
                 absolute_url(
@@ -459,6 +536,159 @@ class TestCrmVisualCoverage:  # pylint: disable=redefined-outer-name
         assert page.get_by_role("heading", name="Daily Income").is_visible()
         capture(page, "income-month")
 
+    def test_mobile_navigation_menu(
+        self, page: Page, live_server, crm_data: CrmData
+    ) -> None:
+        """Use the compact CRM navigation on a narrow viewport."""
+        page.set_viewport_size({"width": 390, "height": 800})
+        log_in(page, live_server, crm_data.staff)
+
+        response = page.goto(
+            absolute_url(
+                live_server, reverse("crm:service-list", kwargs={"kind": "all"})
+            )
+        )
+        assert_loaded(page, response, "Mobile service list")
+        assert (
+            page.locator("#crm-menu-toggle").evaluate("element => element.tabIndex")
+            == 0
+        )
+        page.get_by_text("Menu", exact=True).click()
+        page.get_by_label("CRM navigation").get_by_role("link", name="Invoices").click()
+        page.wait_for_load_state("networkidle")
+        assert page.url == absolute_url(
+            live_server, reverse("crm:invoice-list", kwargs={"kind": "invoice"})
+        )
+
+    def test_income_reports_mobile_layout(
+        self, page: Page, live_server, crm_data: CrmData
+    ) -> None:
+        """Check income charts and compact tables on a narrow viewport."""
+        page.set_viewport_size({"width": 390, "height": 900})
+        log_in(page, live_server, crm_data.staff)
+
+        response = page.goto(absolute_url(live_server, reverse("crm:income")))
+        assert_loaded(page, response, "Mobile income yearly report")
+        assert_no_horizontal_overflow(page)
+        assert_income_charts_fit(page)
+        assert_section_table_does_not_scroll(page, "Yearly category income")
+        capture(page, "income-year-mobile")
+
+        response = page.goto(
+            absolute_url(
+                live_server,
+                reverse("crm:income-month", kwargs={"year": 2026, "month": 3}),
+            )
+        )
+        assert_loaded(page, response, "Mobile income monthly report")
+        assert_no_horizontal_overflow(page)
+        assert_income_charts_fit(page)
+        assert_section_table_does_not_scroll(page, "Category income")
+        capture(page, "income-month-mobile")
+
+    def test_customer_detail_tabs(
+        self, page: Page, live_server, crm_data: CrmData
+    ) -> None:
+        """Visit every customer detail tab through its direct URL."""
+        log_in(page, live_server, crm_data.staff)
+        customer_url = absolute_url(live_server, crm_data.customer.get_absolute_url())
+
+        response = page.goto(customer_url)
+        assert_loaded(page, response, "Customer overview tab")
+        assert (
+            page.locator("#crm-menu-toggle").evaluate("element => element.tabIndex")
+            == -1
+        )
+        assert_customer_tab_selected(page, "Overview")
+        for heading in (
+            "Customer",
+            "Actions",
+            "Customer services",
+            "Agreements",
+            "Donations",
+        ):
+            assert page.get_by_role("heading", name=heading, exact=True).is_visible()
+        assert (
+            page.get_by_role("heading", name="Invoice history", exact=True).count() == 0
+        )
+        assert (
+            page.get_by_role("heading", name="Interaction history", exact=True).count()
+            == 0
+        )
+        assert (
+            page.get_by_role("heading", name="Payment history", exact=True).count() == 0
+        )
+        capture(page, "customer-tab-overview")
+
+        response = page.goto(f"{customer_url}?tab=interactions")
+        assert_loaded(page, response, "Customer interactions tab")
+        assert_customer_tab_selected(page, "Interactions")
+        assert page.get_by_role(
+            "heading", name="Interaction history", exact=True
+        ).first.is_visible()
+        assert_text_visible(page, "Payment completed")
+        assert_text_visible(page, "contract.pdf")
+        assert (
+            page.get_by_role("heading", name="Customer services", exact=True).count()
+            == 0
+        )
+        assert (
+            page.get_by_role("heading", name="Invoice history", exact=True).count() == 0
+        )
+        assert (
+            page.get_by_role("heading", name="Payment history", exact=True).count() == 0
+        )
+        capture(page, "customer-tab-interactions")
+
+        response = page.goto(f"{customer_url}?tab=invoices")
+        assert_loaded(page, response, "Customer invoices tab")
+        assert_customer_tab_selected(page, "Invoices")
+        assert page.get_by_role(
+            "heading", name="Invoice history", exact=True
+        ).is_visible()
+        assert_text_visible(page, "CRM hosted service invoice")
+        assert_text_visible(page, "Issue new invoice")
+        assert (
+            page.get_by_role("heading", name="Customer services", exact=True).count()
+            == 0
+        )
+        assert (
+            page.get_by_role("heading", name="Interaction history", exact=True).count()
+            == 0
+        )
+        assert (
+            page.get_by_role("heading", name="Payment history", exact=True).count() == 0
+        )
+        capture(page, "customer-tab-invoices")
+
+        response = page.goto(f"{customer_url}?tab=payments")
+        assert_loaded(page, response, "Customer payments tab")
+        assert_customer_tab_selected(page, "Payments")
+        assert page.get_by_role(
+            "heading", name="Payment history", exact=True
+        ).is_visible()
+        assert_text_visible(page, "Weblate extended self-hosted support (yearly)")
+        assert (
+            page.get_by_role("heading", name="Customer services", exact=True).count()
+            == 0
+        )
+        assert (
+            page.get_by_role("heading", name="Invoice history", exact=True).count() == 0
+        )
+        assert (
+            page.get_by_role("heading", name="Interaction history", exact=True).count()
+            == 0
+        )
+        capture(page, "customer-tab-payments")
+
+        response = page.goto(f"{customer_url}?tab=unknown")
+        assert_loaded(page, response, "Customer invalid tab fallback")
+        assert_customer_tab_selected(page, "Overview")
+        assert page.get_by_role(
+            "heading", name="Customer services", exact=True
+        ).first.is_visible()
+        capture(page, "customer-tab-invalid")
+
     def test_customer_detail_actions(
         self, page: Page, live_server, crm_data: CrmData
     ) -> None:
@@ -471,13 +701,24 @@ class TestCrmVisualCoverage:  # pylint: disable=redefined-outer-name
         assert_loaded(page, response, "Customer detail")
         capture(page, "customer-detail")
 
+        merge_height = page.locator('input[name="merge"]').evaluate(
+            "element => element.getBoundingClientRect().height"
+        )
+        email_height = page.locator('input[name="email"]').evaluate(
+            "element => element.getBoundingClientRect().height"
+        )
+        assert round(merge_height) == round(email_height)
+
         page.fill('textarea[name="note"]', "Manual CRM note\nFollow-up requested.")
         with fixed_interaction_timestamp(FIXED_TIMESTAMP + timedelta(minutes=10)):
             page.click('input[name="add_manual_note"]')
             page.wait_for_load_state("networkidle")
         assert_no_server_error(page)
+        assert "tab=interactions" in page.url
         assert_text_visible(page, "Manual CRM note", exact=False)
         capture(page, "customer-manual-note")
+        page.get_by_role("link", name="Overview").click()
+        page.wait_for_load_state("networkidle")
 
         hosted_payload = {
             "provider": get_default_saml_provider(),
@@ -695,6 +936,7 @@ class TestCrmVisualCoverage:  # pylint: disable=redefined-outer-name
         )
         assert_loaded(page, response, "Refund invoice detail")
         assert page.get_by_role("heading", name="Confirm refund done").is_visible()
+        assert_summary_chips_same_height(page)
         capture(page, "refund-detail")
         page.fill('input[name="description"]', "Refunded by bank transfer")
         with patch.object(Invoice, "generate_receipt"):
@@ -702,8 +944,8 @@ class TestCrmVisualCoverage:  # pylint: disable=redefined-outer-name
             page.wait_for_load_state("networkidle")
         assert_no_server_error(page)
         assert (
-            page.locator("section.content p")
-            .filter(has_text=re.compile(r"\bpaid\b"))
+            page.locator(".crm-summary-line .crm-badge--success")
+            .filter(has_text="Paid")
             .first.is_visible()
         )
         assert page.get_by_role("heading", name="Confirm refund done").count() == 0


### PR DESCRIPTION
Use reusable CRM layout blocks and responsive styling so dense customer, service, invoice, and income views are easier to scan without relying on Django Admin templates.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
