### PR TITLE
fix(e2e): stabilize CRM manual note timestamp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,9 @@ This file captures agent-specific guidance for working in the Weblate website co
 - Prefer `prek run --all-files` as the primary linting/formatting command because
   it runs the repository's configured pre-commit framework checks.
 - `prek` is a third-party reimplementation of the `pre-commit` tool.
+- End-to-end screenshots are used for visual comparison and must remain
+  deterministic between test runs. Avoid runtime-dependent content such as
+  current timestamps in captured screenshots.
 - Use `pytest` to run the test suite: `pytest weblate_web`.
 - Use `pylint` to lint the Python code: `pylint weblate_web/`
 - Use `mypy` to type check the code: `mypy weblate_web/`

--- a/weblate_web/tests_e2e/test_crm.py
+++ b/weblate_web/tests_e2e/test_crm.py
@@ -182,11 +182,35 @@ def fixed_interaction_timestamp(timestamp: datetime) -> Iterator[None]:
     """Pin action-created interaction timestamps before visual captures."""
     field = Interaction._meta.get_field("timestamp")  # pylint: disable=protected-access
     original_default = field.default
+    original_cached_default = field.__dict__.pop("_get_default", None)
     field.default = lambda: timestamp
     try:
         yield
     finally:
         field.default = original_default
+        field.__dict__.pop("_get_default", None)
+        if original_cached_default is not None:
+            field.__dict__["_get_default"] = original_cached_default
+
+
+def test_fixed_interaction_timestamp_rebuilds_cached_default(  # pylint: disable=redefined-outer-name
+    crm_data: CrmData,
+) -> None:
+    """Ensure visual-test interactions use the pinned timestamp."""
+    field = Interaction._meta.get_field("timestamp")  # pylint: disable=protected-access
+    field.get_default()
+
+    timestamp = FIXED_TIMESTAMP + timedelta(minutes=10)
+    with fixed_interaction_timestamp(timestamp):
+        interaction = crm_data.customer.interaction_set.create(
+            origin=Interaction.Origin.MANUAL_NOTE,
+            summary="Manual CRM note",
+            content="Manual CRM note",
+            user=crm_data.staff,
+        )
+
+    assert interaction.timestamp == timestamp
+    assert Interaction.objects.get(pk=interaction.pk).timestamp == timestamp
 
 
 @pytest.fixture


### PR DESCRIPTION
Invalidate Django's cached field default so manual-note visual screenshots do not vary between test runs.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
