### PR TITLE
fix(payments): keep stale payment attempts pending

### DIFF
--- a/weblate_web/payments/backends.py
+++ b/weblate_web/payments/backends.py
@@ -368,6 +368,9 @@ class Backend:
             return False
         if status:
             return self.success()
+        if self.get_duplicate_invoice_payment():
+            self.failure(notify=False)
+            return False
         self.failure()
         return False
 
@@ -561,18 +564,6 @@ class Backend:
             return None
         return self.payment.draft_invoice, paid_payment
 
-    def reject_other_invoice_payments(self) -> None:
-        invoice = self.payment.paid_invoice
-        if invoice is None:
-            return
-        reason = gettext("Invoice already paid")
-        for payment in invoice.draft_payment_set.filter(
-            backend__gt="", state__in={Payment.NEW, Payment.PENDING}
-        ).exclude(pk=self.payment.pk):
-            payment.state = Payment.REJECTED
-            payment.details["reject_reason"] = reason
-            payment.save(update_fields=["state", "details"])
-
     def success(self) -> bool:
         if duplicate_invoice_payment := self.get_duplicate_invoice_payment():
             invoice, paid_payment = duplicate_invoice_payment
@@ -585,16 +576,16 @@ class Backend:
 
         self.generate_invoice()
         self.payment.save()
-        self.reject_other_invoice_payments()
 
         self.send_notification("payment_completed")
         return True
 
-    def failure(self) -> None:
+    def failure(self, *, notify: bool = True) -> None:
         self.payment.state = Payment.REJECTED
         self.payment.save()
 
-        self.send_notification("payment_failed")
+        if notify:
+            self.send_notification("payment_failed")
 
 
 @register_backend
@@ -824,6 +815,7 @@ class FioBank(Backend):
                         )
 
                 processed = False
+                duplicate_matches: list[Invoice] = []
 
                 # Process all matches
                 for invoice in Invoice.objects.filter(
@@ -843,19 +835,13 @@ class FioBank(Backend):
                             f"{invoice.number}: skipping, underpaid, {amount} instead of {invoice.total_amount}"
                         )
                         continue
-                    if invoice.paid_payment_set.exists():
-                        cls.record_duplicate_bank_payment(
-                            invoice, entry, amount, currency
-                        )
-                        processed = True
-                        continue
-                    if invoice.draft_payment_set.filter(
-                        paid_invoice__isnull=False
-                    ).exists():
-                        cls.record_duplicate_bank_payment(
-                            invoice, entry, amount, currency
-                        )
-                        processed = True
+                    if (
+                        invoice.paid_payment_set.exists()
+                        or invoice.draft_payment_set.filter(
+                            paid_invoice__isnull=False
+                        ).exists()
+                    ):
+                        duplicate_matches.append(invoice)
                         continue
 
                     # Fetch payment(s)
@@ -883,6 +869,13 @@ class FioBank(Backend):
                     backend.success()
                     processed = True
                     break
+
+                if not processed and duplicate_matches:
+                    for invoice in duplicate_matches:
+                        cls.record_duplicate_bank_payment(
+                            invoice, entry, amount, currency
+                        )
+                    processed = True
 
                 # Warn about not processed payment
                 if not processed and entry["account_number"] not in SKIP_ACCOUNTS:

--- a/weblate_web/payments/tests.py
+++ b/weblate_web/payments/tests.py
@@ -587,7 +587,14 @@ class BackendTest(BackendBaseTestCase):
         self.assertEqual(placeholder.backend, "")
         self.assertEqual(placeholder.state, Payment.NEW)
         response = self.client.get(placeholder.get_payment_url())
-        self.assertEqual(response.status_code, 200)
+        self.assertRedirects(response, "/en/", fetch_redirect_response=False)
+        response = self.client.post(
+            placeholder.get_payment_url(), {"method": "thepay2-card"}
+        )
+        self.assertRedirects(response, "/en/", fetch_redirect_response=False)
+        placeholder.refresh_from_db()
+        self.assertEqual(placeholder.backend, "")
+        self.assertEqual(placeholder.state, Payment.NEW)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "Your payment on weblate.org")
         mail.outbox = []
@@ -618,8 +625,8 @@ class BackendTest(BackendBaseTestCase):
         )
         card_payment.refresh_from_db()
         self.assertEqual(card_payment.backend, "thepay2-card")
-        self.assertEqual(card_payment.state, Payment.REJECTED)
-        self.assertEqual(card_payment.details["reject_reason"], "Invoice already paid")
+        self.assertEqual(card_payment.state, Payment.PENDING)
+        self.assertNotIn("reject_reason", card_payment.details)
         self.assertIsNone(card_payment.paid_invoice)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "Your payment on weblate.org")
@@ -646,14 +653,12 @@ class BackendTest(BackendBaseTestCase):
         self.assertEqual(payment.backend, "fio-bank")
         card_payment.refresh_from_db()
         self.assertEqual(card_payment.backend, "thepay2-card")
-        self.assertEqual(card_payment.state, Payment.REJECTED)
-        self.assertEqual(card_payment.details["reject_reason"], "Invoice already paid")
+        self.assertEqual(card_payment.state, Payment.NEW)
+        self.assertNotIn("reject_reason", card_payment.details)
         self.assertIsNone(card_payment.paid_invoice)
         old_fio_payment.refresh_from_db()
-        self.assertEqual(old_fio_payment.state, Payment.REJECTED)
-        self.assertEqual(
-            old_fio_payment.details["reject_reason"], "Invoice already paid"
-        )
+        self.assertEqual(old_fio_payment.state, Payment.PENDING)
+        self.assertNotIn("reject_reason", old_fio_payment.details)
         self.assertIsNone(old_fio_payment.paid_invoice)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "Your payment on weblate.org")
@@ -672,7 +677,8 @@ class BackendTest(BackendBaseTestCase):
         self.mock_fio_payment(invoice)
         FioBank.fetch_payments()
         card_payment.refresh_from_db()
-        self.assertEqual(card_payment.state, Payment.REJECTED)
+        self.assertEqual(card_payment.state, Payment.PENDING)
+        self.assertNotIn("reject_reason", card_payment.details)
         self.assertIsNone(card_payment.paid_invoice)
         mail.outbox = []
 
@@ -702,6 +708,124 @@ class BackendTest(BackendBaseTestCase):
             f"Duplicate payment for paid invoice {invoice.number}",
         )
         self.assertEqual(len(mail.outbox), 0)
+
+    @responses.activate
+    @override_settings(
+        FIO_TOKEN="test-token",  # noqa: S106
+    )
+    @override_settings(**THEPAY2_MOCK_SETTINGS)
+    def test_late_card_failure_after_bank_payment_skips_failed_mail(self) -> None:
+        invoice = self.create_invoice()
+        card_payment = invoice.create_payment(backend="thepay2-card")
+        card_payment.state = Payment.PENDING
+        card_payment.save(update_fields=["state"])
+
+        self.mock_fio_payment(invoice)
+        FioBank.fetch_payments()
+        card_payment.refresh_from_db()
+        self.assertEqual(card_payment.state, Payment.PENDING)
+        mail.outbox = []
+
+        responses.get(
+            f"https://demo.api.thepay.cz/v1/projects/42/payments/{card_payment.pk}?merchant_id=00000000-0000-0000-0000-000000000000",
+            json={
+                "uid": str(card_payment.pk),
+                "project_id": 1,
+                "order_id": "CZ12131415",
+                "state": "error",
+                "events": [
+                    {
+                        "occured_at": "2021-04-20T11:05:49.000000Z",
+                        "type": "payment_cancelled",
+                    }
+                ],
+            },
+        )
+        backend = get_backend("thepay2-card")(card_payment)
+        self.assertFalse(backend.complete(None))
+
+        card_payment.refresh_from_db()
+        self.assertEqual(card_payment.state, Payment.REJECTED)
+        self.assertEqual(card_payment.details["reject_reason"], "Payment cancelled")
+        self.assertIsNone(card_payment.paid_invoice)
+        self.assertEqual(invoice.paid_payment_set.count(), 1)
+        self.assertFalse(
+            self.customer.interaction_set.filter(
+                origin=Interaction.Origin.MANUAL_NOTE
+            ).exists()
+        )
+        self.assertEqual(len(mail.outbox), 0)
+
+    @responses.activate
+    @override_settings(
+        FIO_TOKEN="test-token",  # noqa: S106
+    )
+    @override_settings(**THEPAY2_MOCK_SETTINGS)
+    def test_late_pending_card_after_bank_payment_hides_payment_link(self) -> None:
+        invoice = self.create_invoice()
+        card_payment = invoice.create_payment(backend="thepay2-card")
+        card_payment.state = Payment.PENDING
+        card_payment.details["pay_url"] = "https://gate.thepay.cz/12345/pay"
+        card_payment.save(update_fields=["state", "details"])
+
+        self.mock_fio_payment(invoice)
+        FioBank.fetch_payments()
+        card_payment.refresh_from_db()
+        self.assertEqual(card_payment.state, Payment.PENDING)
+        mail.outbox = []
+
+        responses.get(
+            f"https://demo.api.thepay.cz/v1/projects/42/payments/{card_payment.pk}?merchant_id=00000000-0000-0000-0000-000000000000",
+            json={
+                "uid": str(card_payment.pk),
+                "project_id": 1,
+                "order_id": "CZ12131415",
+                "state": "waiting_for_payment",
+            },
+        )
+        response = self.client.get(f"/en/payment/{card_payment.pk}/complete/")
+        self.assertRedirects(response, "/en/", fetch_redirect_response=False)
+
+        card_payment.refresh_from_db()
+        self.assertEqual(card_payment.state, Payment.PENDING)
+        self.assertEqual(
+            card_payment.details["pay_url"], "https://gate.thepay.cz/12345/pay"
+        )
+        self.assertIsNone(card_payment.paid_invoice)
+        self.assertEqual(invoice.paid_payment_set.count(), 1)
+        self.assertEqual(len(mail.outbox), 0)
+
+    @responses.activate
+    @override_settings(
+        FIO_TOKEN="test-token",  # noqa: S106
+    )
+    def test_invoice_bank_defers_duplicate_when_transfer_pays_other_invoice(
+        self,
+    ) -> None:
+        paid_invoice = self.create_invoice()
+        card_payment = paid_invoice.create_payment(backend="thepay2-card")
+        get_backend("thepay2-card")(card_payment).success()
+        unpaid_invoice = self.create_invoice()
+        mail.outbox = []
+
+        self.mock_fio_payment(
+            unpaid_invoice,
+            payment_message=f"{paid_invoice.number} {unpaid_invoice.number}",
+        )
+        FioBank.fetch_payments()
+
+        self.assertEqual(paid_invoice.paid_payment_set.count(), 1)
+        self.assertTrue(unpaid_invoice.paid_payment_set.exists())
+        self.assertFalse(
+            self.customer.interaction_set.filter(
+                origin=Interaction.Origin.MANUAL_NOTE
+            ).exists()
+        )
+        self.customer.refresh_from_db()
+        self.assertIsNone(self.customer.follow_up_at)
+        self.assertEqual(self.customer.follow_up_note, "")
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "Your payment on weblate.org")
 
     @responses.activate
     @override_settings(

--- a/weblate_web/views.py
+++ b/weblate_web/views.py
@@ -393,6 +393,19 @@ class PaymentView(FormView, SingleObjectMixin):
             f"{self.object.customer.origin}?payment={self.object.pk}"
         )
 
+    def is_draft_invoice_paid(self) -> bool:
+        draft_invoice = self.object.draft_invoice
+        return draft_invoice is not None and draft_invoice.is_paid
+
+    def redirect_paid_draft_invoice(self) -> HttpResponse:
+        messages.info(
+            self.request,
+            gettext(
+                "This invoice has already been paid. Please sign in to view details."
+            ),
+        )
+        return redirect("home")
+
     def get_context_data(self, **kwargs):
         kwargs = super().get_context_data(**kwargs)
         kwargs["can_pay"] = self.can_pay
@@ -440,6 +453,8 @@ class PaymentView(FormView, SingleObjectMixin):
     def dispatch(self, request: HttpRequest, *args, **kwargs):
         with transaction.atomic():
             self.object = self.get_object()
+            if self.object.state == Payment.NEW and self.is_draft_invoice_paid():
+                return self.redirect_paid_draft_invoice()
             customer = self.object.customer
             self.can_pay = not customer.is_empty
             result = self.validate_customer(customer)
@@ -584,6 +599,8 @@ class CompleteView(PaymentView):
 
             # User should choose method for new payment
             if self.object.state == Payment.NEW:
+                if self.is_draft_invoice_paid():
+                    return self.redirect_paid_draft_invoice()
                 return redirect("payment", pk=self.object.pk)
 
             # Get backend and refetch payment from the database
@@ -604,6 +621,8 @@ class CompleteView(PaymentView):
             backend.complete(self.request)
             # If payment is still pending, display info page
             if backend.payment.state == Payment.PENDING:
+                if self.is_draft_invoice_paid():
+                    return self.redirect_paid_draft_invoice()
                 if backend.name == "fio-bank":
                     messages.info(
                         request,


### PR DESCRIPTION
Do not locally reject processor-backed drafts after bank payment because that does not cancel them at the processor. Leave them pending for later callbacks, block paid placeholders from starting new payments, and defer duplicate bank notes until no payable invoice consumes the transfer.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
