### PR TITLE
fix(discovery): avoid leaking activation tokens

### DIFF
--- a/weblate_web/models.py
+++ b/weblate_web/models.py
@@ -24,6 +24,7 @@ from decimal import ROUND_CEILING, Decimal
 from io import BytesIO
 from math import ceil
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit, urlunsplit
 from uuid import uuid4
 
 import html2text
@@ -76,6 +77,39 @@ if TYPE_CHECKING:
     from weblate_web.invoices.models import InvoiceKind
 
 ServiceSuggestion = tuple[str, str, str, str, str, str, int | None]
+
+
+def normalize_site_url_for_lock(url: str) -> str:
+    try:
+        parts = urlsplit(url)
+        scheme = parts.scheme.lower()
+        hostname = parts.hostname
+        port = parts.port
+    except ValueError:
+        return url.rstrip("/")
+
+    netloc = parts.netloc.lower()
+    if hostname:
+        host = hostname.lower()
+        if ":" in host:
+            host = f"[{host}]"
+        if port and (scheme, port) not in {("http", 80), ("https", 443)}:
+            host = f"{host}:{port}"
+        userinfo = ""
+        if "@" in parts.netloc:
+            userinfo = f"{parts.netloc.rsplit('@', 1)[0]}@"
+        netloc = f"{userinfo}{host}"
+
+    return urlunsplit(
+        (
+            scheme,
+            netloc,
+            parts.path.rstrip("/"),
+            parts.query,
+            parts.fragment,
+        )
+    )
+
 
 ALLOWED_IMAGES = {"image/jpeg", "image/png"}
 PILLOW_VALIDATION_ERRORS = (
@@ -794,6 +828,7 @@ class Service(models.Model):
     # Discover integration
     matched_projects: list[Project]
     non_matched_projects_count: int
+    is_pending_discovery_activation: bool
 
     objects = ServiceQuerySet.as_manager()
 
@@ -832,12 +867,11 @@ class Service(models.Model):
         return self.site_url
 
     @property
-    def needs_token(self):
+    def needs_token(self) -> bool:
         if self.is_donation:
             return False
-        return (
-            self.status not in {"hosted", "shared", "community"}
-            or self.backup_subscriptions
+        return self.status not in {"hosted", "shared", "community"} or bool(
+            self.backup_subscriptions
         )
 
     def projects_limit(self) -> str:
@@ -1226,6 +1260,15 @@ class Service(models.Model):
         if self.site_url_lock:
             reports = reports.filter(site_url=self.site_url)
         return reports.order_by("-timestamp")[:10]
+
+
+def is_pending_discovery_activation(service: Service) -> bool:
+    return (
+        not service.is_donation
+        and service.site_url_lock
+        and bool(service.site_url)
+        and service.last_report is None
+    )
 
 
 class SubscriptionQuerySet(models.QuerySet["Subscription"]):
@@ -1707,6 +1750,7 @@ class Report(models.Model):
         using=None,
         update_fields=None,
     ) -> None:
+        self.site_url = normalize_site_url_for_lock(self.site_url)
         super().save(
             force_insert=force_insert,
             force_update=force_update,
@@ -1718,7 +1762,11 @@ class Report(models.Model):
             return
 
         self.service.discoverable = self.discoverable
-        self.service.site_url = self.site_url
+        self.service.site_url = (
+            normalize_site_url_for_lock(self.site_url)
+            if self.service.site_url_lock
+            else self.site_url
+        )
         self.service.site_title = self.site_title
         self.service.site_version = self.version
         self.service.site_users = self.users
@@ -1735,7 +1783,9 @@ class Report(models.Model):
         )
 
     def is_valid_site_url(self) -> bool:
-        return not self.service.site_url_lock or self.site_url == self.service.site_url
+        return not self.service.site_url_lock or normalize_site_url_for_lock(
+            self.site_url
+        ) == normalize_site_url_for_lock(self.service.site_url)
 
     def create_locked_site_url_followup(self) -> None:
         note = _("Locked URL mismatch: %(url)s") % {"url": self.site_url}

--- a/weblate_web/templates/snippets/service.html
+++ b/weblate_web/templates/snippets/service.html
@@ -28,13 +28,13 @@
 
   <div class="form-line clear"></div>
 
-  {% if service.needs_token %}
+  {% if service.needs_token or service.is_pending_discovery_activation %}
     <div class="form-line service-text-formatting bdr-btm">
       <div class="line-left p-top">{% translate "Activation token" %}</div>
       <div class="line-right">
         <input value="{{ service.secret }}" readonly class="fullwidth">
         <br />
-        {% if service.site_url %}
+        {% if service.site_url and service.needs_token and not service.is_pending_discovery_activation %}
           <a class="button button-med-100 inline"
              href="{{ service.site_url }}/manage/?activation={{ service.secret }}">{% translate "Activate" %}</a>
         {% endif %}

--- a/weblate_web/templates/subscription/discovery-add.html
+++ b/weblate_web/templates/subscription/discovery-add.html
@@ -39,7 +39,7 @@
             <div class="form-line">
               <div class="line-left">{% translate "Next step" %}</div>
               <div class="line-right">
-                <p class="help">{% translate "You will be redirected to the server in question to confirm its listing." %}</p>
+                <p class="help">{% translate "Activate the listing from your Weblate management page using the activation token shown after saving." %}</p>
               </div>
               <div class="clear"></div>
             </div>

--- a/weblate_web/tests.py
+++ b/weblate_web/tests.py
@@ -61,6 +61,8 @@ from .models import (
     add_subscription_past_payments,
     get_donation_package,
     get_donation_reward_package_name,
+    is_pending_discovery_activation,
+    normalize_site_url_for_lock,
     process_payment,
     sync_packages,
     validate_bitmap,
@@ -3050,6 +3052,28 @@ class APITest(UserTestCase):
             raise ValueError("Missing package expectation!")
         return service
 
+    def _post_support_report(
+        self,
+        service: Service,
+        site_url: str,
+        *,
+        public_projects: list[dict[str, str]] | None = None,
+    ):
+        data: dict[str, Any] = {
+            "secret": service.secret,
+            "site_url": site_url,
+            "discoverable": "1",
+        }
+        if public_projects is not None:
+            data["public_projects"] = json.dumps(public_projects)
+        response = self.client.post(
+            "/api/support/",
+            data,
+            headers={"user-agent": "Weblate/1.2.3"},
+        )
+        self.assertEqual(response.status_code, 200)
+        return response
+
     def test_support(self) -> None:
         self.perform_support()
 
@@ -3144,21 +3168,26 @@ class APITest(UserTestCase):
         self.assertEqual(service.project_set.count(), 0)
 
     def test_support_site_url_lock(self) -> None:
+        self.assertEqual(
+            normalize_site_url_for_lock("HTTPS://Allowed.Example.com:443/"),
+            "https://allowed.example.com",
+        )
+        self.assertEqual(
+            normalize_site_url_for_lock("http://allowed.example.com:80/"),
+            "http://allowed.example.com",
+        )
+        self.assertEqual(
+            normalize_site_url_for_lock("https://allowed.example.com:8443/"),
+            "https://allowed.example.com:8443",
+        )
+
         service = self.perform_support()
         service.site_url = "https://allowed.example.com"
         service.site_url_lock = True
         service.save(update_fields=["site_url", "site_url_lock"])
 
-        response = self.client.post(
-            "/api/support/",
-            {
-                "secret": service.secret,
-                "site_url": "https://wrong.example.com",
-                "discoverable": "1",
-            },
-            headers={"user-agent": "Weblate/1.2.3"},
-        )
-        self.assertEqual(response.status_code, 200)
+        response = self._post_support_report(service, "https://wrong.example.com")
+        self.assertFalse(response.json()["in_limits"])
         service = Service.objects.get(pk=service.pk)
         self.assertFalse(service.discoverable)
         self.assertEqual(service.site_url, "https://allowed.example.com")
@@ -3173,16 +3202,7 @@ class APITest(UserTestCase):
             followup.details["reported_site_url"], "https://wrong.example.com"
         )
 
-        response = self.client.post(
-            "/api/support/",
-            {
-                "secret": service.secret,
-                "site_url": "https://other-wrong.example.com",
-                "discoverable": "1",
-            },
-            headers={"user-agent": "Weblate/1.2.3"},
-        )
-        self.assertEqual(response.status_code, 200)
+        self._post_support_report(service, "https://other-wrong.example.com")
         self.assertEqual(service.followups.count(), 1)
         followup.refresh_from_db()
         self.assertEqual(
@@ -3190,16 +3210,7 @@ class APITest(UserTestCase):
             "https://other-wrong.example.com",
         )
 
-        response = self.client.post(
-            "/api/support/",
-            {
-                "secret": service.secret,
-                "site_url": "https://allowed.example.com",
-                "discoverable": "1",
-            },
-            headers={"user-agent": "Weblate/1.2.3"},
-        )
-        self.assertEqual(response.status_code, 200)
+        self._post_support_report(service, "https://allowed.example.com")
         service = Service.objects.get(pk=service.pk)
         self.assertTrue(service.discoverable)
         self.assertEqual(service.followups.count(), 1)
@@ -3208,6 +3219,46 @@ class APITest(UserTestCase):
             followup.details["reported_site_url"],
             "https://other-wrong.example.com",
         )
+
+        self._post_support_report(service, "https://allowed.example.com:443/")
+        service = Service.objects.get(pk=service.pk)
+        self.assertTrue(service.discoverable)
+
+        self._post_support_report(
+            service,
+            "https://allowed.example.com",
+            public_projects=[
+                {
+                    "name": "Allowed project",
+                    "url": "/projects/allowed/",
+                    "web": "https://allowed.example.com/projects/allowed/",
+                }
+            ],
+        )
+        self.assertEqual(service.project_set.count(), 1)
+        project = service.project_set.get()
+        self.assertEqual(project.name, "Allowed project")
+
+        response = self._post_support_report(
+            service,
+            "https://wrong.example.com",
+            public_projects=[
+                {
+                    "name": "Wrong project",
+                    "url": "/projects/wrong/",
+                    "web": "https://wrong.example.com/projects/wrong/",
+                }
+            ],
+        )
+        self.assertFalse(response.json()["in_limits"])
+        self.assertEqual(service.project_set.count(), 1)
+        project = service.project_set.get()
+        self.assertEqual(project.name, "Allowed project")
+
+        response = self._post_support_report(service, "http://[")
+        self.assertFalse(response.json()["in_limits"])
+        service = Service.objects.get(pk=service.pk)
+        self.assertEqual(service.site_url, "https://allowed.example.com")
 
     def test_user(self) -> None:
         user = self.create_user()
@@ -5592,9 +5643,17 @@ class StorageBoxTestCase(FakturaceTestCase):
 class DiscoveryTestCase(UserTestCase):
     def test_create(self):
         # This requires login
-        response = self.client.get("/subscription/discovery/", follow=True)
+        response = self.client.get("/subscription/discovery/")
         self.assertRedirects(
-            response, "/admin/login/?next=%2Fen%2Fsubscription%2Fdiscovery%2F"
+            response,
+            "/en/subscription/discovery/",
+            fetch_redirect_response=False,
+        )
+        response = self.client.get("/en/subscription/discovery/")
+        self.assertRedirects(
+            response,
+            f"{settings.LOGIN_URL}?next=/en/subscription/discovery/",
+            fetch_redirect_response=False,
         )
         self.login()
         # Test exact URL because that is used from Weblate
@@ -5612,9 +5671,67 @@ class DiscoveryTestCase(UserTestCase):
         )
         service = Service.objects.get()
         self.assertEqual(service.site_url, "http://localhost")
+        self.assertTrue(service.site_url_lock)
         self.assertNotEqual(service.secret, "")
+        self.assertFalse(service.needs_token)
+        self.assertTrue(is_pending_discovery_activation(service))
         self.assertRedirects(
             response,
-            f"http://localhost/manage/?activation={service.secret}",
+            "/user/",
             fetch_redirect_response=False,
         )
+        self.assertNotIn("activation=", response["Location"])
+        self.assertNotIn("http://localhost", response["Location"])
+
+        regular_service = Service.objects.create(
+            customer=service.customer,
+            status="basic",
+            site_url="https://support.example.com",
+        )
+        self.assertTrue(regular_service.needs_token)
+        self.assertFalse(is_pending_discovery_activation(regular_service))
+        response = self.client.get("/en/user/")
+        self.assertContains(
+            response,
+            f'href="https://support.example.com/manage/?activation={regular_service.secret}"',
+        )
+
+    def test_create_does_not_redirect_to_site_url(self) -> None:
+        self.login()
+        response = self.client.post(
+            "/en/subscription/discovery/",
+            {
+                "site_url": "https://evil.example/",
+                "discover_text": "Discover evil",
+            },
+            follow=True,
+        )
+        service = Service.objects.get()
+        self.assertEqual(service.site_url, "https://evil.example")
+        self.assertTrue(service.site_url_lock)
+        self.assertNotEqual(service.secret, "")
+        self.assertTrue(is_pending_discovery_activation(service))
+        self.assertRedirects(
+            response,
+            "/en/user/",
+        )
+        self.assertContains(response, "Activation token")
+        self.assertContains(response, service.secret)
+        self.assertContains(response, "data-clipboard-text")
+        self.assertNotContains(response, "activation=")
+        self.assertNotContains(response, "evil.example/manage/")
+
+        Package.objects.create(name="community", verbose="Community support", price=0)
+        api_response = self.client.post(
+            "/api/support/",
+            {
+                "secret": service.secret,
+                "site_url": "https://evil.example/",
+                "discoverable": "1",
+            },
+            headers={"user-agent": "Weblate/1.2.3"},
+        )
+        self.assertEqual(api_response.status_code, 200)
+        service = Service.objects.get(pk=service.pk)
+        self.assertFalse(is_pending_discovery_activation(service))
+        self.assertTrue(service.discoverable)

--- a/weblate_web/tests_e2e/test_discovery.py
+++ b/weblate_web/tests_e2e/test_discovery.py
@@ -1,0 +1,86 @@
+#
+# Copyright (C) Weblate
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+End-to-end tests for Discover Weblate registration.
+
+Tests cover:
+- Registering a self-hosted Weblate server for discovery
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+pytestmark = [
+    pytest.mark.django_db,
+    pytest.mark.usefixtures("e2e_setup"),
+]
+
+SCREENSHOT_DIR = Path("test-results")
+
+
+def capture(page: Page, name: str) -> None:
+    """Capture a full-page screenshot for Argos CI."""
+    page.wait_for_load_state("networkidle")
+    SCREENSHOT_DIR.mkdir(exist_ok=True)
+    page.screenshot(
+        path=(SCREENSHOT_DIR / f"discovery-{name}.png").as_posix(), full_page=True
+    )
+
+
+class TestDiscoveryRegistration:
+    """Test suite for Discover Weblate registration."""
+
+    def test_discovery_registration_stays_on_website(
+        self, page: Page, live_server, authenticated_user
+    ):
+        """Test discovery registration does not redirect to the submitted URL."""
+        page.goto(f"{live_server.url}/admin/login/")
+        page.fill('input[name="username"]', "testuser")
+        page.fill('input[name="password"]', "testpassword123")
+        page.click('input[type="submit"]')
+        page.wait_for_load_state("networkidle")
+
+        response = page.goto(f"{live_server.url}/en/subscription/discovery/")
+        assert response is not None
+        assert response.ok, f"Discovery page returned status {response.status}"
+        capture(page, "registration-form")
+
+        page.fill('input[name="site_url"]', "https://evil.example")
+        page.fill('textarea[name="discover_text"]', "Discover evil")
+        page.click('input[type="submit"]')
+        page.wait_for_load_state("networkidle")
+
+        assert "/user/" in page.url, f"Not on user page. URL: {page.url}"
+        assert "evil.example" not in page.url
+        assert "activation=" not in page.url
+        assert not page.locator("text=Server Error").is_visible()
+        assert page.get_by_text("Activation token", exact=True).is_visible()
+        assert page.locator(
+            'input[value="e2e-fixed-service-secret-token-0123456789abcdef0123456789abcd"]'
+        ).is_visible()
+        assert page.locator('a[href*="activation="]').count() == 0
+        capture(page, "activation-token")

--- a/weblate_web/views.py
+++ b/weblate_web/views.py
@@ -80,6 +80,7 @@ from weblate_web.models import (
     add_subscription_past_payments,
     get_donation_package_verbose,
     get_donation_reward_package_names,
+    is_pending_discovery_activation,
     process_donation,
     process_subscription,
 )
@@ -174,6 +175,11 @@ def get_customer(
     )[0]
     customer.users.add(request.user)
     return customer
+
+
+def prepare_service_for_render(service: Service) -> Service:
+    service.is_pending_discovery_activation = is_pending_discovery_activation(service)
+    return service
 
 
 @require_POST
@@ -313,7 +319,7 @@ def api_hosted(request: HttpRequest) -> JsonResponse:
 @csrf_exempt
 def api_support(request: HttpRequest) -> JsonResponse:
     service = get_object_or_404(Service, secret=request.POST.get("secret", ""))
-    service.report_set.create(
+    report = service.report_set.create(
         site_url=request.POST.get("site_url", ""),
         site_title=request.POST.get("site_title", ""),
         ssh_key=request.POST.get("ssh_key", ""),
@@ -327,9 +333,10 @@ def api_support(request: HttpRequest) -> JsonResponse:
         version=extract_weblate_version(request),
         discoverable=bool(request.POST.get("discoverable")),
     )
+    is_valid_site_url = report.is_valid_site_url()
     service.update_status()
     service.create_backup()
-    if "public_projects" in request.POST:
+    if is_valid_site_url and "public_projects" in request.POST:
         current_projects = set(service.project_set.values_list("name", "url", "web"))
         for project in json.loads(request.POST["public_projects"]):
             # Skip unexpected data
@@ -354,7 +361,7 @@ def api_support(request: HttpRequest) -> JsonResponse:
             else "",
             "expiry": service.expires,
             "backup_repository": service.backup_repository,
-            "in_limits": service.check_in_limits(),
+            "in_limits": is_valid_site_url and service.check_in_limits(),
             "limits": service.get_limits(),
             "has_subscription": service.latest_subscription is not None,
         }
@@ -883,6 +890,8 @@ class AddDiscoveryView(CreateView):
         """If the form is valid, save the associated model."""
         instance = form.instance
         instance.customer = get_customer(self.request, instance)
+        instance.site_url = instance.site_url.rstrip("/")
+        instance.site_url_lock = True
         discover_url = instance.site_url
         discover_text = form.cleaned_data.get("discover_text", "N/A")
         mail_admins(
@@ -891,9 +900,13 @@ class AddDiscoveryView(CreateView):
         )
         result = super().form_valid(form)
         instance.customer.users.add(self.request.user)
-        if instance.site_url:
-            url = instance.site_url.rstrip("/")
-            return redirect(f"{url}/manage/?activation={instance.secret}")
+        messages.info(
+            self.request,
+            gettext(
+                "Activate the listing from your Weblate management page using the "
+                "activation token shown below."
+            ),
+        )
         return result
 
 
@@ -1051,6 +1064,7 @@ def customer_user(request, pk):
 @user_passes_test(lambda u: u.is_superuser)
 def subscription_view(request, pk):
     service = get_object_or_404(Service, pk=pk)
+    prepare_service_for_render(service)
     return render(request, "service.html", {"service": service})
 
 
@@ -1251,9 +1265,12 @@ class UserView(TemplateView):
 
     def get_context_data(self, **kwargs):
         data = super().get_context_data(**kwargs)
-        data["user_services"] = Service.objects.customer_services().filter(
-            customer__users=self.request.user,
-        )
+        data["user_services"] = [
+            prepare_service_for_render(service)
+            for service in Service.objects.customer_services().filter(
+                customer__users=self.request.user,
+            )
+        ]
         data["user_donations"] = Service.objects.donations().filter(
             customer__users=self.request.user,
         )


### PR DESCRIPTION
Keep discovery activation on weblate.org instead of redirecting to user-supplied URLs, and lock the registered URL to the reporting instance.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
