### PR TITLE
feat(crm): include historical BTC income

### DIFF
--- a/weblate_web/crm/templates/crm/income.html
+++ b/weblate_web/crm/templates/crm/income.html
@@ -24,18 +24,6 @@
     {% endfor %}
   </nav>
 
-  {% if excluded_btc_count %}
-    <div class="crm-warning">
-      <p>
-        {% blocktranslate count count=excluded_btc_count trimmed %}
-          {{ count }} BTC payment is excluded because no deterministic EUR conversion rate is available.
-        {% plural %}
-          {{ count }} BTC payments are excluded because no deterministic EUR conversion rate is available.
-        {% endblocktranslate %}
-      </p>
-    </div>
-  {% endif %}
-
   <section class="crm-section content">
     {% if is_monthly %}
       {% blocktranslate with month=current_month|stringformat:"02d" asvar section_title %}Income by Category - {{ current_year }}/{{ month }}{% endblocktranslate %}

--- a/weblate_web/crm/tests.py
+++ b/weblate_web/crm/tests.py
@@ -2714,22 +2714,21 @@ class IncomeTrackingTestCase(BaseCRMTestCase):
 
         self.assertEqual(response.context["total_income"], Decimal(80))
 
-    def test_income_excludes_btc_with_disclosure(self):
+    def test_income_converts_historical_btc_payments_to_eur(self):
+        payment_date = date(2023, 3, 1)
+        ExchangeRates.datacache[payment_date.isoformat()] = {
+            "EUR": Decimal(25),
+        }
+        ExchangeRates.btc_datacache[payment_date.isoformat()] = Decimal(1_000_000)
         self.create_historical_payment(
-            date(2023, 3, 1),
+            payment_date,
             100_000_000,
             currency=Payment.CURRENCY_BTC,
         )
 
         response = self.client.get(reverse("crm:income-year", kwargs={"year": 2023}))
 
-        self.assertEqual(response.context["total_income"], Decimal(0))
-        self.assertEqual(response.context["excluded_btc_count"], 1)
-        self.assertContains(
-            response,
-            "1 BTC payment is excluded because no deterministic EUR conversion "
-            "rate is available.",
-        )
+        self.assertEqual(response.context["total_income"], Decimal(40_000))
 
     @responses.activate
     def test_income_monthly_view(self):

--- a/weblate_web/crm/views.py
+++ b/weblate_web/crm/views.py
@@ -1138,6 +1138,7 @@ class IncomeView(CRMMixin, TemplateView):  # type: ignore[misc]
     title = "Income Tracking"
     MAX_MONTH_INDEX = date.max.year * 12 - 1
     INVOICE_DATA_START = date(2024, 11, 1)
+    SATOSHIS_PER_BTC = Decimal(100_000_000)
 
     # Chart configuration
     CHART_WIDTH = 800
@@ -1440,13 +1441,13 @@ class IncomeView(CRMMixin, TemplateView):  # type: ignore[misc]
         return cache[key]
 
     def _convert_to_eur(
-        self, amount: Decimal, currency: Currency, rate_date: date
+        self, amount: Decimal, currency: str, rate_date: date
     ) -> Decimal:
-        if currency == Currency.EUR:
+        if currency == Currency.EUR.label:
             return amount
         return (
             amount
-            * self._get_exchange_rate(currency.label, rate_date)
+            * self._get_exchange_rate(currency, rate_date)
             / self._get_exchange_rate(Currency.EUR.label, rate_date)
         )
 
@@ -1546,7 +1547,7 @@ class IncomeView(CRMMixin, TemplateView):  # type: ignore[misc]
                 "period": row["period"],
                 "total_no_vat": self._convert_to_eur(
                     row["total_no_vat"],
-                    Currency(row["currency"]),
+                    Currency(row["currency"]).label,
                     row["tax_date"],
                 ),
             }
@@ -1703,18 +1704,16 @@ class IncomeView(CRMMixin, TemplateView):  # type: ignore[misc]
         }
 
         summary_rows: list[IncomeSummaryRow] = []
-        excluded_btc_ids = getattr(self, "_excluded_btc_payment_ids", None)
-        if excluded_btc_ids is None:
-            excluded_btc_ids = set()
-            self._excluded_btc_payment_ids = excluded_btc_ids
-
         for payment in payments:
+            amount = Decimal(str(payment.amount_without_vat))
             if payment.currency == Payment.CURRENCY_BTC:
-                excluded_btc_ids.add(payment.pk)
-                continue
-
+                amount /= self.SATOSHIS_PER_BTC
+                payment_currency = "BTC"
+            else:
+                payment_currency = Currency(
+                    CURRENCY_MAP_FROM_PAYMENT[payment.currency]
+                ).label
             payment_date = timezone.localtime(payment.created).date()
-            payment_currency = Currency(CURRENCY_MAP_FROM_PAYMENT[payment.currency])
             summary_rows.append(
                 {
                     "pk": payment.pk,
@@ -1723,7 +1722,7 @@ class IncomeView(CRMMixin, TemplateView):  # type: ignore[misc]
                     ),
                     "period": self._get_payment_period(payment_date, period),
                     "total_no_vat": self._convert_to_eur(
-                        Decimal(str(payment.amount_without_vat)),
+                        amount,
                         payment_currency,
                         payment_date,
                     ),
@@ -2083,7 +2082,6 @@ class IncomeView(CRMMixin, TemplateView):  # type: ignore[misc]
         return list(range(earliest_year, current_year + 2))
 
     def get_context_data(self, **kwargs):
-        self._excluded_btc_payment_ids = set()
         context = super().get_context_data(**kwargs)
         year = self.get_year()
         month = self.get_month()
@@ -2139,5 +2137,4 @@ class IncomeView(CRMMixin, TemplateView):  # type: ignore[misc]
             )
             context["is_monthly"] = False
 
-        context["excluded_btc_count"] = len(self._excluded_btc_payment_ids)
         return context

--- a/weblate_web/exchange_rates.py
+++ b/weblate_web/exchange_rates.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import json
 import logging
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import ClassVar
 
@@ -11,8 +11,10 @@ import requests
 
 logger = logging.getLogger(__name__)
 RATE_URL = "https://api.cnb.cz/cnbapi/exrates/daily"
+BTC_RATE_URL = "https://api.exchange.coinbase.com/products/BTC-EUR/candles"
 CACHE_DIR = Path.home() / ".cache" / "fakturace"
 EXCHANGE_MARKUP = Decimal("1.1")
+BTC_GRANULARITY = 86400
 
 
 class DecimalEncoder(json.JSONEncoder):
@@ -38,11 +40,55 @@ class UncachedExchangeRates:
         return {item["currencyCode"]: item["rate"] for item in payload["rates"]}
 
     @classmethod
+    def download_btc(cls, date: str) -> Decimal:
+        rate_date = datetime.date.fromisoformat(date)
+        next_date = rate_date + datetime.timedelta(days=1)
+        response = requests.get(
+            BTC_RATE_URL,
+            params={
+                "start": f"{date}T00:00:00Z",
+                "end": f"{next_date.isoformat()}T00:00:00Z",
+                "granularity": str(BTC_GRANULARITY),
+            },
+            timeout=10,
+        )
+        response.raise_for_status()
+        try:
+            payload = json.loads(response.text, parse_float=Decimal)
+        except json.JSONDecodeError as error:
+            raise InvalidDataError(str(error)) from error
+
+        expected_timestamp = int(
+            datetime.datetime.combine(
+                rate_date, datetime.time.min, tzinfo=datetime.UTC
+            ).timestamp()
+        )
+        if not isinstance(payload, list):
+            raise InvalidDataError("BTC rate response is not a list")
+        for candle in payload:
+            if (
+                isinstance(candle, list)
+                and len(candle) >= 5
+                and candle[0] == expected_timestamp
+            ):
+                # Coinbase candles contain time, low, high, open, close, volume.
+                try:
+                    btc_eur_rate = Decimal(candle[4])
+                except (InvalidOperation, TypeError, ValueError) as error:
+                    raise InvalidDataError("BTC closing rate is invalid") from error
+                if btc_eur_rate <= 0:
+                    raise InvalidDataError("BTC closing rate is not positive")
+                return btc_eur_rate * cls.get("EUR", rate_date)
+        raise InvalidDataError(f"BTC rate response has no candle for {date}")
+
+    @classmethod
     def get(cls, currency: str, date: datetime.date, *, recursion: int = 0) -> Decimal:
         date_iso = date.isoformat()
         if currency == "CZK":
             return Decimal(1)
         try:
+            if currency == "BTC":
+                return cls.download_btc(date_iso)
             rates = cls.download(date_iso)
         except (requests.RequestException, InvalidDataError):
             logger.exception("failed to fetch exchange rate data")
@@ -67,6 +113,7 @@ class UncachedExchangeRates:
 
 class ExchangeRates(UncachedExchangeRates):
     datacache: ClassVar[dict[str, dict[str, Decimal]]] = {}
+    btc_datacache: ClassVar[dict[str, Decimal]] = {}
 
     @classmethod
     def download(cls, date: str) -> dict[str, Decimal]:
@@ -87,3 +134,19 @@ class ExchangeRates(UncachedExchangeRates):
             cache_file.write_text(json.dumps(cls.datacache[date], cls=DecimalEncoder))
 
         return cls.datacache[date]
+
+    @classmethod
+    def download_btc(cls, date: str) -> Decimal:
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        cache_file = CACHE_DIR / f"rate-btc-{date}"
+
+        if date not in cls.btc_datacache and cache_file.exists():
+            cls.btc_datacache[date] = Decimal(json.loads(cache_file.read_text()))
+
+        if date not in cls.btc_datacache:
+            cls.btc_datacache[date] = super().download_btc(date)
+            cache_file.write_text(
+                json.dumps(cls.btc_datacache[date], cls=DecimalEncoder)
+            )
+
+        return cls.btc_datacache[date]

--- a/weblate_web/tests.py
+++ b/weblate_web/tests.py
@@ -40,7 +40,7 @@ from wlc import WeblateException
 from weblate_web.invoices.models import Discount, Invoice, InvoiceCategory, InvoiceKind
 from weblate_web.payments.models import Customer, CustomerFollowUp, Payment
 
-from .exchange_rates import ExchangeRates, UncachedExchangeRates
+from .exchange_rates import BTC_RATE_URL, ExchangeRates, UncachedExchangeRates
 from .hetzner import generate_random_password
 from .management.commands.backups_sync import Command as BackupsSyncCommand
 from .management.commands.recurring_payments import Command as RecurringPaymentsCommand
@@ -5511,6 +5511,19 @@ class ExchangeRatesTestCase(SimpleTestCase):
     @responses.activate
     def test_czk(self):
         self.assertEqual(UncachedExchangeRates.get("CZK", date(2000, 1, 1)), Decimal(1))
+
+    @responses.activate
+    def test_btc(self):
+        self.mock_rate()
+        responses.get(
+            BTC_RATE_URL,
+            json=[[946684800, 7000, 7200, 7100, 7150, 10]],
+        )
+
+        self.assertEqual(
+            UncachedExchangeRates.get("BTC", date(2000, 1, 1)),
+            Decimal("158887.300"),
+        )
 
     @responses.activate
     def test_fallback(self):


### PR DESCRIPTION
Historical BTC payments were excluded because no deterministic conversion rate was available. Cache daily BTC/EUR rates so past income totals include those payments consistently.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
