### PR TITLE
fix(payments): handle Fio API throttling

### DIFF
--- a/weblate_web/payments/backends.py
+++ b/weblate_web/payments/backends.py
@@ -791,7 +791,7 @@ class FioBank(Backend):
             client = fiobank.FioBank(token=token, decimal=True)
             try:
                 info, transactions = client.last_transactions(from_date=from_date)
-            except requests.RequestException as error:
+            except (fiobank.ThrottlingError, requests.RequestException) as error:
                 sentry_sdk.capture_exception()
                 print(f"Failed to fetch payments: {error}")
                 continue

--- a/weblate_web/payments/tests.py
+++ b/weblate_web/payments/tests.py
@@ -25,6 +25,7 @@ from datetime import date
 from typing import Any, cast
 from unittest.mock import patch
 
+import fiobank
 import responses
 from django.contrib.auth.models import User
 from django.core import mail
@@ -157,6 +158,20 @@ FIO_TRASACTIONS = {
 
 
 class ModelTest(SimpleTestCase):
+    @override_settings(
+        FIO_TOKEN="test-token",  # ruff:ignore[hardcoded-password-func-arg]
+    )
+    @patch("weblate_web.payments.backends.sentry_sdk.capture_exception")
+    @patch("weblate_web.payments.backends.fiobank.FioBank.last_transactions")
+    def test_invoice_bank_throttling(
+        self, last_transactions, capture_exception
+    ) -> None:
+        last_transactions.side_effect = fiobank.ThrottlingError("API throttled")
+
+        FioBank.fetch_payments()
+
+        capture_exception.assert_called_once_with()
+
     def test_vat(self) -> None:
         customer = Customer()
         self.assertFalse(customer.needs_vat)


### PR DESCRIPTION
### Motivation

- The Fio client (`fiobank==5.0.0`) can raise `fiobank.ThrottlingError` on repeated throttled responses which is not a `requests.RequestException` and therefore could escape `FioBank.fetch_payments()` and abort the reconciliation transaction.

### Description

- Catch `fiobank.ThrottlingError` together with `requests.RequestException` in `weblate_web/payments/backends.py` so throttling errors are reported and do not abort processing.
- Add a regression test in `weblate_web/payments/tests.py` that simulates `fiobank.ThrottlingError` and asserts the error is captured via the existing Sentry/output path.
- Import `fiobank` in the tests file to allow the simulated exception to be raised by the patched `last_transactions()` call.

### Testing

- Ran the targeted unit test `pytest -q weblate_web/payments/tests.py -k throttling`, which passed.
- Ran static checks `pylint weblate_web/` and `mypy weblate_web/`, which produced no new issues for the modified code.
- Ran `prek run --all-files`; repository hooks passed locally except JSON schema validation failed to download an external schema due to an environment proxy returning HTTP 403.
- Attempted the broader test run for `pytest -q weblate_web`, but the environment blocks external EU VIES service calls so the full suite could not be reliably completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cba558194832990acfa0cc33bcdf6)