### PR TITLE
fix(migrations): restore MySQL FULLTEXT index in squashed migration

### DIFF
--- a/weblate_web/migrations/0001_squashed_0052_discoveryactivation.py
+++ b/weblate_web/migrations/0001_squashed_0052_discoveryactivation.py
@@ -31,6 +31,14 @@ from django.db import migrations, models
 import weblate_web.models
 
 
+def create_project_name_fulltext_index(apps, schema_editor) -> None:
+    if schema_editor.connection.vendor == "mysql":
+        schema_editor.execute(
+            "CREATE FULLTEXT INDEX weblate_web_project_name_fulltext "
+            "ON weblate_web_project(name)"
+        )
+
+
 class Migration(migrations.Migration):
     replaces = [
         ("weblate_web", "0001_squashed_0030_service_note"),
@@ -485,6 +493,7 @@ class Migration(migrations.Migration):
                 "verbose_name_plural": "Weblate projects",
             },
         ),
+        migrations.RunPython(code=create_project_name_fulltext_index, atomic=False),
         migrations.CreateModel(
             name="DiscoveryActivation",
             fields=[


### PR DESCRIPTION
### Motivation

- The squashed migration recreated `Project.name` with only a B-tree index and omitted the original MySQL-only `FULLTEXT` index, causing `MATCH (...) AGAINST (...)` queries to fail on fresh MySQL/MariaDB deployments.

### Description

- Restored a MySQL-only migration operation that creates the `weblate_web_project_name_fulltext` FULLTEXT index by adding `create_project_name_fulltext_index` to `weblate_web/migrations/0001_squashed_0052_discoveryactivation.py`.
- The migration function checks `schema_editor.connection.vendor == "mysql"` and executes `CREATE FULLTEXT INDEX weblate_web_project_name_fulltext ON weblate_web_project(name)` only for MySQL, and the operation is added immediately after the `Project` model creation with `migrations.RunPython(..., atomic=False)` to match the original behavior.
- Non-MySQL databases remain unaffected because the operation is a no-op for other backends.

### Testing

- Ran `uv sync --dev` successfully and executed the repository pre-commit hooks with `uv run prek run --all-files`, where local hooks passed but `check-jsonschema` failed to download a remote schema due to an environment proxy error.
- Ran unit tests with `uv run pytest weblate_web`, which reported `375 passed` and `86 failed` where the failures are environment-related (blocked VIES network access and missing generated static assets) and not related to the migration change.
- Ran static checks `uv run pylint weblate_web/` and `uv run mypy weblate_web/` which completed without errors for the modified code, and performed a targeted mock validation that confirmed the migration executes the `CREATE FULLTEXT INDEX` on a mocked MySQL `schema_editor` and does nothing for SQLite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c1ec5cfec8329be19437f6db4a56f)