### PR TITLE
fix(payments): recalculate VAT after billing updates

### DIFF
--- a/weblate_web/payments/models.py
+++ b/weblate_web/payments/models.py
@@ -435,7 +435,9 @@ class Customer(models.Model):
 
     @property
     def needs_vat(self) -> bool:
-        return self.vat_country_code == "CZ" or self.is_eu_enduser
+        return (
+            not self.country_code or self.vat_country_code == "CZ" or self.is_eu_enduser
+        )
 
     @property
     def vat_rate(self) -> int:

--- a/weblate_web/payments/tests.py
+++ b/weblate_web/payments/tests.py
@@ -174,20 +174,25 @@ class ModelTest(SimpleTestCase):
 
     def test_vat(self) -> None:
         customer = Customer()
-        self.assertFalse(customer.needs_vat)
+        self.assertTrue(customer.needs_vat)
+        self.assertEqual(customer.vat_rate, 21)
         customer = Customer(**CUSTOMER)
         # Czech customer needs VAT
         self.assertTrue(customer.needs_vat)
+        self.assertEqual(customer.vat_rate, 21)
         # EU enduser needs VAT
         customer.vat = ""
         self.assertTrue(customer.needs_vat)
+        self.assertEqual(customer.vat_rate, 21)
         # EU company does not need VAT
         customer.vat = "IE6388047V"
         self.assertFalse(customer.needs_vat)
+        self.assertEqual(customer.vat_rate, 0)
         # Non EU customer does not need VAT
         customer.vat = ""
         customer.country = "US"
         self.assertFalse(customer.needs_vat)
+        self.assertEqual(customer.vat_rate, 0)
 
     def test_empty(self) -> None:
         customer = Customer(country="CZ")

--- a/weblate_web/tests.py
+++ b/weblate_web/tests.py
@@ -1200,6 +1200,24 @@ class PaymentCustomerAccessTest(UserTestCase):
         with override("en"):
             return create_payment(user=user, customer=customer)
 
+    def create_draft_payment(
+        self, customer: Customer
+    ) -> tuple[Invoice, Payment, str, str]:
+        invoice = Invoice.objects.create(
+            customer=customer,
+            kind=InvoiceKind.DRAFT,
+            category=InvoiceCategory.HOSTING,
+            vat_rate=customer.vat_rate,
+        )
+        invoice.invoiceitem_set.create(description="Test service", unit_price=100)
+        payment = invoice.create_payment()
+        return (
+            invoice,
+            payment,
+            reverse("payment", kwargs={"pk": payment.pk}),
+            reverse("payment-customer", kwargs={"pk": payment.pk}),
+        )
+
     def test_anonymous_user_can_not_edit_website_payment_customer(self) -> None:
         owner = self.create_user()
         customer = self.create_customer(owner)
@@ -1228,6 +1246,76 @@ class PaymentCustomerAccessTest(UserTestCase):
 
         customer.refresh_from_db()
         self.assertEqual(customer.name, self.edit_data["name"])
+
+    def test_customer_edit_adds_vat_to_linked_draft_and_payment(self) -> None:
+        owner = self.login()
+        customer = self.create_customer(owner)
+        customer.country = "US"
+        customer.save(update_fields=["country"])
+        invoice, payment, payment_url, customer_url = self.create_draft_payment(
+            customer
+        )
+        self.assertEqual(invoice.vat_rate, 0)
+        self.assertEqual(payment.amount, 100)
+
+        response = self.client.post(customer_url, self.edit_data, follow=True)
+
+        self.assertRedirects(response, payment_url)
+        self.assertContains(response, "€121")
+        self.assertContains(response, "(including VAT)")
+        invoice.refresh_from_db()
+        payment.refresh_from_db()
+        self.assertEqual(invoice.vat_rate, 21)
+        self.assertEqual(payment.amount, 121)
+        self.assertTrue(payment.amount_fixed)
+
+    def test_customer_edit_removes_vat_from_linked_draft_and_payment(self) -> None:
+        owner = self.login()
+        customer = self.create_customer(owner)
+        invoice, payment, payment_url, customer_url = self.create_draft_payment(
+            customer
+        )
+        self.assertEqual(invoice.vat_rate, 21)
+        self.assertEqual(payment.amount, 121)
+        edit_data = {**self.edit_data, "country": "US"}
+
+        response = self.client.post(customer_url, edit_data, follow=True)
+
+        self.assertRedirects(response, payment_url)
+        self.assertContains(response, "€100")
+        self.assertNotContains(response, "(including VAT)")
+        invoice.refresh_from_db()
+        payment.refresh_from_db()
+        self.assertEqual(invoice.vat_rate, 0)
+        self.assertEqual(payment.amount, 100)
+        self.assertTrue(payment.amount_fixed)
+
+    def test_customer_edit_does_not_update_linked_proforma(self) -> None:
+        owner = self.login()
+        customer = self.create_customer(owner)
+        invoice = Invoice.objects.create(
+            customer=customer,
+            kind=InvoiceKind.PROFORMA,
+            category=InvoiceCategory.HOSTING,
+            vat_rate=21,
+        )
+        invoice.invoiceitem_set.create(description="Test service", unit_price=100)
+        payment = Payment.objects.create(
+            customer=customer,
+            amount=121,
+            amount_fixed=True,
+            description="Test service",
+            draft_invoice=invoice,
+        )
+        customer_url = reverse("payment-customer", kwargs={"pk": payment.pk})
+        edit_data = {**self.edit_data, "country": "US"}
+
+        self.client.post(customer_url, edit_data)
+
+        invoice.refresh_from_db()
+        payment.refresh_from_db()
+        self.assertEqual(invoice.vat_rate, 21)
+        self.assertEqual(payment.amount, 121)
 
     def test_other_user_can_not_edit_website_payment_customer(self) -> None:
         owner = User.objects.create_user(username="owner", email="owner@example.com")
@@ -1277,8 +1365,10 @@ class PaymentCustomerAccessTest(UserTestCase):
         customer.owners.clear()
 
         self.assertEqual(self.client.get(customer_url).status_code, 200)
-        response = self.client.post(customer_url, self.edit_data)
+        response = self.client.post(customer_url, self.edit_data, follow=True)
         self.assertRedirects(response, payment_url)
+        self.assertContains(response, "€121")
+        self.assertContains(response, "(including VAT)")
 
         customer.refresh_from_db()
         self.assertEqual(customer.name, self.edit_data["name"])
@@ -2156,11 +2246,15 @@ class PaymentTest(FakturaceTestCase):
         self.assertContains(response, "Please provide your billing")
         payment = Payment.objects.all().get()
         self.assertEqual(payment.state, Payment.NEW)
+        self.assertEqual(payment.amount, 50)
+        self.assertEqual(cast("Invoice", payment.draft_invoice).vat_rate, 21)
         customer_url = reverse("payment-customer", kwargs={"pk": payment.uuid})
         payment_url = reverse("payment", kwargs={"pk": payment.uuid})
         self.assertRedirects(response, customer_url)
         response = self.client.post(customer_url, TEST_CUSTOMER, follow=True)
         self.assertContains(response, "Please choose payment method")
+        self.assertContains(response, "€50")
+        self.assertContains(response, "(including VAT)")
         response = self.client.post(payment_url, {"method": "thepay2-card"})
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response.url.startswith("https://gate.thepay.cz/"))  # type: ignore[attr-defined]
@@ -2181,6 +2275,7 @@ class PaymentTest(FakturaceTestCase):
 
         payment.refresh_from_db()
         self.assertEqual(payment.state, Payment.PROCESSED)
+        self.assertEqual(cast("Invoice", payment.paid_invoice).vat_rate, 21)
 
         # Edit customer info
         customer = Customer.objects.get()

--- a/weblate_web/views.py
+++ b/weblate_web/views.py
@@ -70,7 +70,7 @@ from weblate_web.forms import (
     SupportReportForm,
     get_discovery_callback_url,
 )
-from weblate_web.invoices.models import InvoiceKind
+from weblate_web.invoices.models import Invoice, InvoiceKind
 from weblate_web.legal.models import Agreement, AgreementKind
 from weblate_web.models import (
     REWARD_LEVELS,
@@ -602,7 +602,16 @@ class CustomerView(FormView, PaymentObjectMixin):
         return super().form_invalid(form)
 
     def form_valid(self, form):
-        form.save()
+        customer = form.save()
+        if self.object.draft_invoice_id:
+            invoice = Invoice.objects.select_for_update().get(
+                pk=self.object.draft_invoice_id
+            )
+            if invoice.kind == InvoiceKind.DRAFT:
+                invoice.vat_rate = customer.vat_rate
+                invoice.save(update_fields=["vat_rate"])
+                self.object.amount = int(invoice.total_amount)
+                self.object.save(update_fields=["amount"])
         return redirect("payment", pk=self.object.pk)
 
     def get_form_kwargs(self):


### PR DESCRIPTION
Treat incomplete customer data as VAT liable and synchronize linked drafts with their fixed payments, preventing customer-initiated purchases from retaining a stale zero rate.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
