### PR TITLE
fix(payments): match VAT country code aliases

### DIFF
--- a/weblate_web/payments/models.py
+++ b/weblate_web/payments/models.py
@@ -98,6 +98,11 @@ EU_VAT_RATES = {
     "SE": 25,
 }
 
+VAT_COUNTRY_CODE_ALIASES = {
+    "CHE": "CH",
+    "EL": "GR",
+    "XI": "GB",
+}
 VAT_RATE = 21
 DELETED_MAIL = re.compile(r"noreply\+[0-9]+@weblate.org")
 
@@ -374,7 +379,13 @@ class Customer(models.Model):
         return None
 
     def clean(self) -> None:
-        if self.vat and self.vat_country_code != self.country_code:
+        vat_country_code = self.vat_country_code
+        country_code = self.country_code
+        if vat_country_code:
+            vat_country_code = VAT_COUNTRY_CODE_ALIASES.get(
+                vat_country_code, vat_country_code
+            )
+        if self.vat and vat_country_code != country_code:
             raise ValidationError(
                 {"country": gettext_lazy("The country has to match your VAT code")}
             )

--- a/weblate_web/payments/tests.py
+++ b/weblate_web/payments/tests.py
@@ -34,6 +34,7 @@ from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import override_settings
 from django.utils import timezone
+from vies.types import VATIN
 
 from weblate_web.crm.models import Interaction
 from weblate_web.invoices.models import Invoice, InvoiceCategory, InvoiceKind
@@ -210,6 +211,22 @@ class ModelTest(SimpleTestCase):
         customer.country = "IE"
         with self.assertRaises(ValidationError):
             customer.clean()
+
+    def test_clean_vat_country_code_aliases(self) -> None:
+        for vat_country_code, country_code in (
+            ("CHE", "CH"),
+            ("EL", "GR"),
+            ("XI", "GB"),
+        ):
+            with self.subTest(vat_country_code=vat_country_code):
+                customer = Customer(
+                    **{
+                        **CUSTOMER,
+                        "country": country_code,
+                        "vat": VATIN(vat_country_code, "123456789"),
+                    }
+                )
+                customer.clean()
 
     def test_vat_calculation(self) -> None:
         customer = Customer(**CUSTOMER)


### PR DESCRIPTION
VIES and supported VAT identifiers use prefixes that differ from ISO customer country codes. Normalize those aliases when validating the customer country.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
