### PR TITLE
fix(payments): validate VAT on recurring payments

### DIFF
--- a/weblate_web/management/commands/recurring_payments.py
+++ b/weblate_web/management/commands/recurring_payments.py
@@ -23,9 +23,11 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand
 from django.db.models import Max
 from django.utils import timezone
+from django.utils.html import strip_tags
 
 from weblate_web.invoices.models import InvoiceKind
 from weblate_web.models import Service, ServiceKind, Subscription, get_period_delta
@@ -145,10 +147,18 @@ class Command(BaseCommand):
         extra: dict[str, int],
     ) -> None:
         # Allow at most three failures of current payment method
-        rejected_payments = past_payments.filter(
-            state=Payment.REJECTED, repeat=payment.repeat or payment
+        repeated_payments = past_payments.filter(repeat=payment.repeat or payment)
+        rejected_payments = repeated_payments.filter(state=Payment.REJECTED)
+        last_processed = (
+            repeated_payments.filter(state=Payment.PROCESSED)
+            .order_by("-created")
+            .first()
         )
-        if rejected_payments.count() > 3:
+        if last_processed is not None:
+            rejected_payments = rejected_payments.filter(
+                created__gt=last_processed.created
+            )
+        if rejected_payments.count() >= 3:
             payment.recurring = ""
             payment.save()
             return
@@ -177,6 +187,28 @@ class Command(BaseCommand):
             payment.recurring = ""
             payment.save()
             return
+
+        if repeated.customer.vat:
+            validation_failed = False
+            validation_detail = ""
+            try:
+                repeated.customer.prepayment_validation(automated=True)
+            except ValidationError as error:
+                validation_failed = True
+                validation_detail = strip_tags(str(error.message))
+            if repeated.customer.vat_recently_invalid:
+                validation_failed = True
+                validation_detail = strip_tags(
+                    repeated.customer.vat_validation_error["message"]
+                )
+            if validation_failed:
+                repeated.state = Payment.REJECTED
+                repeated.details["failure_code"] = Payment.VAT_VALIDATION_FAILURE
+                if validation_detail:
+                    repeated.details["failure_detail"] = validation_detail
+                repeated.save(update_fields=["state", "details"])
+                repeated.customer.send_notification("payment_failed", payment=repeated)
+                return
 
         # Trigger of the payment
         repeated.trigger_recurring()

--- a/weblate_web/payments/models.py
+++ b/weblate_web/payments/models.py
@@ -40,7 +40,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.text import format_lazy
-from django.utils.translation import gettext_lazy, pgettext_lazy
+from django.utils.translation import gettext, gettext_lazy, pgettext_lazy
 from django_countries.fields import CountryField
 from unidecode import unidecode
 from vies.models import VATINField
@@ -721,6 +721,8 @@ class Payment(models.Model):
     ACCEPTED = 4
     PROCESSED = 5
 
+    VAT_VALIDATION_FAILURE = "vat_validation"
+
     CURRENCY_EUR = 0
     CURRENCY_BTC = 1
     CURRENCY_USD = 2
@@ -796,6 +798,18 @@ class Payment(models.Model):
 
     def get_absolute_url(self):
         return reverse("payment", kwargs={"pk": self.pk})
+
+    def get_reject_reason(self) -> str:
+        if self.details.get("failure_code") == self.VAT_VALIDATION_FAILURE:
+            if failure_detail := self.details.get("failure_detail"):
+                return gettext(
+                    "The VAT ID could not be validated, so the recurring payment was "
+                    "not attempted. Validation service response: {}"
+                ).format(failure_detail)
+            return gettext(
+                "The VAT ID could not be validated, so the recurring payment was not attempted."
+            )
+        return str(self.details.get("reject_reason") or "")
 
     @property
     def is_waiting_for_user(self):

--- a/weblate_web/payments/tests.py
+++ b/weblate_web/payments/tests.py
@@ -345,6 +345,21 @@ class ModelObjectsTestCase(TestCase):
             },
         )
 
+    def test_automated_recent_invalid_vat_skips_validation(self) -> None:
+        customer = self.create_customer_for_vat_validation()
+        customer.vat_validated = timezone.now()
+        customer.vat_validation_state = Customer.VatValidationState.INVALID
+        customer.vat_validation_error = {
+            "vat": str(customer.vat),
+            "code": "INVALID_INPUT",
+            "message": "The VIES service rejected the VAT ID",
+        }
+
+        with patch("weblate_web.payments.models.validate_vatin") as validate:
+            customer.prepayment_validation(automated=True)
+
+        validate.assert_not_called()
+
 
 class BackendBaseTestCase(TestCase):
     backend_name: str = ""

--- a/weblate_web/templates/mail/payment_failed.html
+++ b/weblate_web/templates/mail/payment_failed.html
@@ -5,12 +5,14 @@
 {% block content %}
   <p>{% translate "Your payment on weblate.org has failed." %}</p>
 
-  {% if payment.details.reject_reason %}
-    <p>
-      {% translate "Detailed failure from the payment gateway:" %}
-      {{ payment.details.reject_reason }}
-    </p>
-  {% endif %}
+  {% with reject_reason=payment.get_reject_reason %}
+    {% if reject_reason %}
+      <p>
+        {% translate "Detailed failure reason:" %}
+        {{ reject_reason }}
+      </p>
+    {% endif %}
+  {% endwith %}
 
   <p>{% translate "If concerning a recurring payment, it is retried three times, and if still failing, cancelled." %}</p>
 

--- a/weblate_web/templates/snippets/payment.html
+++ b/weblate_web/templates/snippets/payment.html
@@ -26,8 +26,8 @@
     {% elif payment.state != 5 %}
       {% if payment.is_waiting_for_user %}
         <a class="link invoice-link" href="{{ payment.get_absolute_url }}">{% translate "Pay now" %}</a>
-      {% elif payment.details.reject_reason %}
-        {{ payment.get_state_display }}: {{ payment.details.reject_reason }}
+      {% elif payment.get_reject_reason %}
+        {{ payment.get_state_display }}: {{ payment.get_reject_reason }}
       {% else %}
         {{ payment.get_state_display }}
       {% endif %}

--- a/weblate_web/tests.py
+++ b/weblate_web/tests.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from io import BytesIO, StringIO
 from pathlib import Path
@@ -4624,6 +4624,186 @@ class ExpiryTest(FakturaceTestCase):
     PAYMENT_DEBUG=True,
 )
 class ServiceTest(FakturaceTestCase):
+    @staticmethod
+    def set_customer_vat(
+        service: Service,
+        *,
+        state: Customer.VatValidationState = Customer.VatValidationState.VALID,
+        validated: datetime | None = None,
+        error: dict[str, str] | None = None,
+    ) -> None:
+        vat = f"{TEST_CUSTOMER['vat_0']}{TEST_CUSTOMER['vat_1']}"
+        Customer.objects.filter(pk=service.customer_id).update(
+            vat=vat,
+            vat_validated=validated or timezone.now(),
+            vat_validation_state=state,
+            vat_validation_error=error or {},
+        )
+
+    def test_recurring_payment_revalidates_vat(self) -> None:
+        service = self.create_service(years=0, days=-2)
+        subscription = service.subscription_set.get()
+        expires = subscription.expires
+        self.set_customer_vat(service)
+
+        with patch("weblate_web.payments.models.validate_vatin") as validate:
+            RecurringPaymentsCommand.handle_subscriptions()
+
+        validate.assert_called_once()
+        repeated = subscription.payment_obj.payment_set.get()
+        self.assertEqual(repeated.state, Payment.PROCESSED)
+        subscription.refresh_from_db()
+        self.assertGreater(subscription.expires, expires)
+
+    def test_recurring_payment_rejects_invalid_vat(self) -> None:
+        service = self.create_service(years=0, days=-2)
+        subscription = service.subscription_set.get()
+        expires = subscription.expires
+        self.set_customer_vat(
+            service,
+            validated=timezone.now() - timedelta(days=VAT_VALIDITY_DAYS),
+        )
+        error = ValidationError(
+            "The VIES service rejected the VAT ID", code="INVALID_INPUT"
+        )
+
+        with patch("weblate_web.payments.models.validate_vatin", side_effect=error):
+            RecurringPaymentsCommand.handle_subscriptions()
+
+        repeated = subscription.payment_obj.payment_set.get()
+        self.assertEqual(repeated.state, Payment.REJECTED)
+        self.assertEqual(
+            repeated.details,
+            {
+                "failure_code": Payment.VAT_VALIDATION_FAILURE,
+                "failure_detail": "The VIES service rejected the VAT ID",
+            },
+        )
+        self.assertEqual(
+            repeated.get_reject_reason(),
+            "The VAT ID could not be validated, so the recurring payment was not attempted. Validation service response: The VIES service rejected the VAT ID",
+        )
+        with patch(
+            "weblate_web.payments.models.gettext",
+            return_value="Localized VAT validation failure: {}",
+        ):
+            localized_email = render_to_string(
+                "mail/payment_failed.html", {"payment": repeated}
+            )
+        self.assertIn(
+            "Localized VAT validation failure: The VIES service rejected the VAT ID",
+            localized_email,
+        )
+        subscription.refresh_from_db()
+        self.assertEqual(subscription.expires, expires)
+        self.assertEqual(
+            set(service.customer.interaction_set.values_list("origin", flat=True)),
+            {Interaction.Origin.EMAIL, Interaction.Origin.VIES},
+        )
+        messages = self.assert_notifications("Your payment on weblate.org failed")
+        html_content = cast("str", messages[0].alternatives[0][0])
+        self.assertIn("Detailed failure reason:", html_content)
+        self.assertIn(repeated.get_reject_reason(), html_content)
+
+    def test_recurring_payment_rejects_transient_vat_failure(self) -> None:
+        service = self.create_service(years=0, days=-2)
+        subscription = service.subscription_set.get()
+        expires = subscription.expires
+        self.set_customer_vat(
+            service,
+            validated=timezone.now() - timedelta(days=VAT_VALIDITY_DAYS),
+        )
+        error = ValidationError(
+            "The VIES service is unavailable", code="other:Error: TIMEOUT"
+        )
+
+        with patch("weblate_web.payments.models.validate_vatin", side_effect=error):
+            RecurringPaymentsCommand.handle_subscriptions()
+
+        repeated = subscription.payment_obj.payment_set.get()
+        self.assertEqual(repeated.state, Payment.REJECTED)
+        self.assertEqual(
+            repeated.details["failure_detail"], "The VIES service is unavailable"
+        )
+        subscription.refresh_from_db()
+        self.assertEqual(subscription.expires, expires)
+        self.assertFalse(
+            service.customer.interaction_set.filter(
+                origin=Interaction.Origin.VIES
+            ).exists()
+        )
+        self.assert_notifications("Your payment on weblate.org failed")
+
+    def test_recurring_invoice_reuses_invalid_vat_and_stops_after_retries(
+        self,
+    ) -> None:
+        service = self.create_service(years=0, days=-2)
+        subscription = service.subscription_set.get()
+        payment = subscription.payment_obj
+        payment.paid_invoice = subscription.create_invoice(kind=InvoiceKind.INVOICE)
+        payment.save(update_fields=["paid_invoice"])
+        vat = f"{TEST_CUSTOMER['vat_0']}{TEST_CUSTOMER['vat_1']}"
+        self.set_customer_vat(
+            service,
+            state=Customer.VatValidationState.INVALID,
+            error={
+                "vat": vat,
+                "code": "INVALID_INPUT",
+                "message": "The VIES service rejected the VAT ID",
+            },
+        )
+
+        with patch("weblate_web.payments.models.validate_vatin") as validate:
+            for _attempt in range(4):
+                RecurringPaymentsCommand.handle_subscriptions()
+
+        validate.assert_not_called()
+        payment.refresh_from_db()
+        self.assertEqual(payment.recurring, "")
+        self.assertEqual(payment.payment_set.filter(state=Payment.REJECTED).count(), 3)
+        self.assert_notifications(*["Your payment on weblate.org failed"] * 3)
+
+    def test_recurring_invoice_success_resets_vat_failure_count(self) -> None:
+        service = self.create_service(years=0, days=-2)
+        subscription = service.subscription_set.get()
+        payment = subscription.payment_obj
+        payment.paid_invoice = subscription.create_invoice(kind=InvoiceKind.INVOICE)
+        payment.save(update_fields=["paid_invoice"])
+        vat = f"{TEST_CUSTOMER['vat_0']}{TEST_CUSTOMER['vat_1']}"
+        invalid_vat = {
+            "vat": vat,
+            "code": "INVALID_INPUT",
+            "message": "The VIES service rejected the VAT ID",
+        }
+        self.set_customer_vat(
+            service,
+            state=Customer.VatValidationState.INVALID,
+            error=invalid_vat,
+        )
+
+        for _attempt in range(2):
+            RecurringPaymentsCommand.handle_subscriptions()
+
+        self.set_customer_vat(service)
+        with patch("weblate_web.payments.models.validate_vatin") as validate:
+            RecurringPaymentsCommand.handle_subscriptions()
+        validate.assert_called_once()
+        self.assertEqual(payment.payment_set.filter(state=Payment.PROCESSED).count(), 1)
+
+        subscription.expires = timezone.now() - timedelta(days=2)
+        subscription.save(update_fields=["expires"])
+        self.set_customer_vat(
+            service,
+            state=Customer.VatValidationState.INVALID,
+            error=invalid_vat,
+        )
+        for _attempt in range(2):
+            RecurringPaymentsCommand.handle_subscriptions()
+
+        payment.refresh_from_db()
+        self.assertEqual(payment.recurring, "y")
+        self.assertEqual(payment.payment_set.filter(state=Payment.REJECTED).count(), 4)
+
     @responses.activate
     def test_upcoming_payment(self) -> None:
         service = self.create_service(

--- a/weblate_web/views.py
+++ b/weblate_web/views.py
@@ -783,7 +783,7 @@ def process_payment(request):
         messages.error(
             request,
             gettext("The payment was rejected: {}").format(
-                payment.details.get("reject_reason", gettext("Unknown reason"))
+                payment.get_reject_reason() or gettext("Unknown reason")
             ),
         )
     elif payment.state == Payment.ACCEPTED:


### PR DESCRIPTION
Recheck VAT IDs before charging recurring payments. Record validation failures as rejected attempts so invalid VAT IDs cannot renew and existing retry handling applies.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
