### PR TITLE
fix(invoices): align zero-rated tax classifications

### DIFF
--- a/weblate_web/invoices/models.py
+++ b/weblate_web/invoices/models.py
@@ -311,6 +311,13 @@ class InvoiceStatusBadge:
     show_due_date: bool = False
 
 
+@dataclass(frozen=True)
+class _EN16931TaxDetails:
+    category: TaxCategoryCode
+    rate: Decimal | None
+    exemption_reason: str | None
+
+
 class Discount(models.Model):
     description = models.CharField(max_length=200, unique=True)
     percents = models.IntegerField(
@@ -758,12 +765,10 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
         add_element(output, "PlnenoDPH", self.tax_date.isoformat())
         add_element(output, "Splatno", self.due_date.isoformat())
         add_element(output, "DatSkPoh", self.tax_date.isoformat())
-        if self.customer.country == "CZ":
+        if self.customer.country == "CZ" or self.vat_rate:
             add_element(output, "KodDPH", "19Ř01,02")
-        elif self.customer.vat:
+        elif self.customer.is_eu:
             add_element(output, "KodDPH", "19Ř21")
-        elif self.customer.is_eu_enduser:
-            add_element(output, "KodDPH", "19Ř01,02")
         else:
             add_element(output, "KodDPH", "19Ř26")
         add_element(output, "ZjednD", "0")
@@ -855,6 +860,27 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
             email=self.customer.email or None,
         )
 
+    def _get_en_16931_tax_details(self) -> _EN16931TaxDetails:
+        if self.vat_rate:
+            return _EN16931TaxDetails(
+                category=TaxCategoryCode.STANDARD_RATE,
+                rate=Decimal(self.vat_rate),
+                exemption_reason=None,
+            )
+        if self.customer.is_eu:
+            return _EN16931TaxDetails(
+                category=TaxCategoryCode.REVERSE_CHARGE,
+                rate=Decimal(0),
+                exemption_reason="Reverse charge",
+            )
+        return _EN16931TaxDetails(
+            category=TaxCategoryCode.OUT_OF_SCOPE,
+            rate=None,
+            exemption_reason=(
+                "Not subject to VAT because the place of supply is outside the EU"
+            ),
+        )
+
     def get_en_16931_xml(self) -> EN16931Invoice:
         if self.kind == InvoiceKind.INVOICE:
             type_code = DocumentTypeCode.INVOICE
@@ -871,17 +897,13 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
         )
         tax_basis_amount = Money(self.total_amount_no_vat, self.get_currency_display())
 
-        tax_category = (
-            TaxCategoryCode.STANDARD_RATE
-            if self.vat_rate
-            else TaxCategoryCode.REVERSE_CHARGE
-        )
+        tax_details = self._get_en_16931_tax_details()
         tax = Tax(
-            category_code=tax_category,
+            category_code=tax_details.category,
             calculated_amount=tax_amount,
             basis_amount=tax_basis_amount,
-            rate_percent=Decimal(self.vat_rate),
-            exemption_reason="Reverse charge" if not self.vat_rate else None,
+            rate_percent=tax_details.rate,
+            exemption_reason=tax_details.exemption_reason,
         )
 
         line_items: list[EN16931LineItem] = []
@@ -903,8 +925,8 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
                         actual_amount=Money(
                             -item.total_price, self.get_currency_display()
                         ),
-                        tax_rate=Decimal(self.vat_rate),
-                        tax_category=tax_category,
+                        tax_rate=tax_details.rate,
+                        tax_category=tax_details.category,
                     )
                 )
                 line_total_amount.amount -= item.total_price
@@ -927,8 +949,8 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
                         billed_total=Money(
                             item.total_price, self.get_currency_display()
                         ),
-                        tax_rate=Decimal(self.vat_rate),
-                        tax_category=tax_category,
+                        tax_rate=tax_details.rate,
+                        tax_category=tax_details.category,
                         billing_period=(item.start_date, item.end_date)
                         if item.start_date and item.end_date
                         else None,
@@ -945,8 +967,8 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
                     net_price=Money(Decimal(0), self.get_currency_display()),
                     billed_quantity=(Decimal(0), QuantityCode.ONE),
                     billed_total=Money(Decimal(0), self.get_currency_display()),
-                    tax_rate=Decimal(self.vat_rate),
-                    tax_category=tax_category,
+                    tax_rate=tax_details.rate,
+                    tax_category=tax_details.category,
                     billing_period=None,
                 )
             )
@@ -960,8 +982,8 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
                     actual_amount=Money(
                         -self.total_discount, self.get_currency_display()
                     ),
-                    tax_rate=Decimal(self.vat_rate),
-                    tax_category=tax_category,
+                    tax_rate=tax_details.rate,
+                    tax_category=tax_details.category,
                 )
             )
 
@@ -1014,7 +1036,16 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
                     city=COMPANY_CITY,
                     line_one=COMPANY_ADDRESS,
                 ),
-                vat_id=COMPANY_VAT_ID,
+                vat_id=(
+                    None
+                    if tax_details.category == TaxCategoryCode.OUT_OF_SCOPE
+                    else COMPANY_VAT_ID
+                ),
+                tax_number=(
+                    COMPANY_ID
+                    if tax_details.category == TaxCategoryCode.OUT_OF_SCOPE
+                    else None
+                ),
                 email=COMPANY_SALES_EMAIL,
             ),
             buyer=TradeParty(
@@ -1026,7 +1057,11 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
                     line_one=self.customer.address,
                     line_two=self.customer.address_2 or None,
                 ),
-                vat_id=self.customer.vat or None,
+                vat_id=(
+                    None
+                    if tax_details.category == TaxCategoryCode.OUT_OF_SCOPE
+                    else self.customer.vat or None
+                ),
                 email=self.customer.email or None,
                 contact=self.get_buyer_trade_contact(),
             ),

--- a/weblate_web/invoices/tests.py
+++ b/weblate_web/invoices/tests.py
@@ -17,6 +17,7 @@ from drafthorse.utils import validate_xml  # type: ignore[import-untyped]
 from lxml import etree
 from pycheval import generate_xml
 from pycheval.quantities import QuantityCode
+from pycheval.type_codes import TaxCategoryCode
 
 from weblate_web.models import Package, PackageCategory
 from weblate_web.payments.models import Customer
@@ -46,13 +47,14 @@ class InvoiceTestCase(UserTestCase):
         contact_point: str = "",
         email: str = "",
         accounting_reference: str = "",
+        country: str = "cz",
     ) -> Customer:
         return Customer.objects.create(
             name="Zkušební zákazník",
             address="Street 42",
             city="City",
             postcode="424242",
-            country="cz",
+            country=country,
             user_id=-1,
             vat=vat,
             contact_point=contact_point,
@@ -70,6 +72,7 @@ class InvoiceTestCase(UserTestCase):
         customer_contact_point: str = "",
         customer_email: str = "",
         accounting_reference: str = "",
+        country: str = "cz",
         vat: str = "",
         kind: InvoiceKind = InvoiceKind.INVOICE,
         currency: Currency = Currency.EUR,
@@ -86,6 +89,7 @@ class InvoiceTestCase(UserTestCase):
                 contact_point=customer_contact_point,
                 email=customer_email,
                 accounting_reference=accounting_reference,
+                country=country,
             ),
             discount=discount,
             vat_rate=vat_rate,
@@ -125,6 +129,7 @@ class InvoiceTestCase(UserTestCase):
         customer_contact_point: str = "",
         customer_email: str = "",
         accounting_reference: str = "",
+        country: str = "cz",
         vat: str = "",
         kind: InvoiceKind = InvoiceKind.INVOICE,
         tax_date: date | None = None,
@@ -140,6 +145,7 @@ class InvoiceTestCase(UserTestCase):
             customer_contact_point=customer_contact_point,
             customer_email=customer_email,
             accounting_reference=accounting_reference,
+            country=country,
             vat=vat,
             kind=kind,
             tax_date=tax_date,
@@ -212,6 +218,130 @@ class InvoiceTestCase(UserTestCase):
 
     def get_einvoice_xml_tree(self, invoice: Invoice) -> etree._Element:
         return etree.fromstring(generate_xml(invoice.get_en_16931_xml()).encode())
+
+    def get_money_s3_xml_tree(self, invoice: Invoice) -> etree._Element:
+        document, invoices = invoice.get_invoice_xml_root()
+        invoice.get_money_s3_xml_tree(invoices)
+        return document
+
+    def test_accounting_export_tax_classifications(self) -> None:
+        cases = (
+            (
+                "Czech standard rate",
+                "CZ",
+                21,
+                "",
+                TaxCategoryCode.STANDARD_RATE,
+                Decimal(21),
+                None,
+                "19Ř01,02",
+            ),
+            (
+                "EU reverse charge",
+                "DE",
+                0,
+                "DE123456789",
+                TaxCategoryCode.REVERSE_CHARGE,
+                Decimal(0),
+                "Reverse charge",
+                "19Ř21",
+            ),
+            (
+                "outside EU",
+                "US",
+                0,
+                "US123456789",
+                TaxCategoryCode.OUT_OF_SCOPE,
+                None,
+                "Not subject to VAT because the place of supply is outside the EU",
+                "19Ř26",
+            ),
+        )
+
+        for (
+            name,
+            country,
+            vat_rate,
+            vat,
+            expected_category,
+            expected_rate,
+            expected_reason,
+            expected_money_s3_code,
+        ) in cases:
+            with self.subTest(name):
+                invoice = self.create_invoice(
+                    country=country,
+                    vat_rate=vat_rate,
+                    vat=vat,
+                )
+
+                einvoice = invoice.get_en_16931_xml()
+                self.assertEqual(einvoice.tax[0].category_code, expected_category)
+                self.assertEqual(einvoice.tax[0].rate_percent, expected_rate)
+                self.assertEqual(einvoice.tax[0].exemption_reason, expected_reason)
+                self.assertEqual(
+                    {item.tax_category for item in einvoice.line_items},
+                    {expected_category},
+                )
+                self.assertEqual(
+                    {item.tax_rate for item in einvoice.line_items}, {expected_rate}
+                )
+
+                money_s3 = self.get_money_s3_xml_tree(invoice)
+                S3_SCHEMA.assertValid(money_s3)
+                self.assertEqual(
+                    money_s3.findtext(".//FaktVyd/KodDPH"), expected_money_s3_code
+                )
+
+    def test_outside_eu_en_16931_omits_vat_details(self) -> None:
+        invoice = self.create_invoice(
+            country="US",
+            vat="US123456789",
+            discount=Discount.objects.create(
+                description="Outside EU discount", percents=10
+            ),
+        )
+        invoice.invoiceitem_set.create(description="Credit", unit_price=-10)
+
+        einvoice = invoice.get_en_16931_xml()
+        self.assertEqual(
+            {allowance.tax_category for allowance in einvoice.allowances},
+            {TaxCategoryCode.OUT_OF_SCOPE},
+        )
+        self.assertEqual(
+            {allowance.tax_rate for allowance in einvoice.allowances}, {None}
+        )
+
+        xml = generate_xml(einvoice).encode()
+        validate_xml(xml, "FACTUR-X_EN16931")
+        root = etree.fromstring(xml)
+        namespaces = EN16931Validator().namespaces
+        categories = root.xpath(
+            ".//ram:ApplicableTradeTax/ram:CategoryCode/text() | "
+            ".//ram:CategoryTradeTax/ram:CategoryCode/text()",
+            namespaces=namespaces,
+        )
+        self.assertTrue(categories)
+        self.assertEqual(set(categories), {TaxCategoryCode.OUT_OF_SCOPE})
+        self.assertEqual(
+            root.xpath(".//ram:RateApplicablePercent", namespaces=namespaces), []
+        )
+        self.assertEqual(
+            root.xpath(
+                ".//ram:SpecifiedTaxRegistration/ram:ID[@schemeID='VA']",
+                namespaces=namespaces,
+            ),
+            [],
+        )
+        self.assertEqual(root.xpath(".//ram:TaxTotalAmount", namespaces=namespaces), [])
+        self.assertEqual(
+            root.xpath(".//ram:ExemptionReason/text()", namespaces=namespaces),
+            ["Not subject to VAT because the place of supply is outside the EU"],
+        )
+        self.assertEqual(
+            root.xpath(".//ram:CalculatedAmount/text()", namespaces=namespaces),
+            ["0.00"],
+        )
 
     def test_customer_reference_is_buyer_order_reference(self) -> None:
         invoice = self.create_invoice(customer_reference="PO123456")


### PR DESCRIPTION
Non-EU zero-rated invoices were exported as reverse charge in EN 16931, and Money S3 could misclassify them from VAT ID presence. Align both accounting exports with the invoice's EU place-of-supply treatment.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
