### PR TITLE
fix(payments): calculate VAT amounts with Decimal

### DIFF
--- a/weblate_web/payments/models.py
+++ b/weblate_web/payments/models.py
@@ -23,6 +23,7 @@ import os.path
 import re
 import uuid
 from datetime import timedelta
+from decimal import Decimal
 from email.message import Message
 from typing import TYPE_CHECKING, cast
 
@@ -824,11 +825,12 @@ class Payment(models.Model):
         return self.amount
 
     @property
-    def vat_amount(self):
+    def vat_amount(self) -> Decimal:
+        amount = Decimal(self.amount)
         if self.customer.needs_vat and not self.amount_fixed:
             rate = 100 + self.customer.vat_rate
-            return round(rate * self.amount / 100, 2)
-        return self.amount
+            return rate * amount / 100
+        return amount
 
     @property
     def amount_without_vat(self):

--- a/weblate_web/payments/tests.py
+++ b/weblate_web/payments/tests.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 from copy import deepcopy
 from datetime import date
+from decimal import Decimal
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -231,17 +232,22 @@ class ModelTest(SimpleTestCase):
     def test_vat_calculation(self) -> None:
         customer = Customer(**CUSTOMER)
         payment = Payment(customer=customer, amount=100)
-        self.assertEqual(payment.vat_amount, 121)
+        self.assertEqual(payment.vat_amount, Decimal(121))
         payment = Payment(customer=customer, amount=100, amount_fixed=True)
-        self.assertEqual(payment.vat_amount, 100)
+        self.assertEqual(payment.vat_amount, Decimal(100))
         self.assertAlmostEqual(payment.amount_without_vat, 82.64, places=2)
 
         customer.vat = "IE6388047V"
         payment = Payment(customer=customer, amount=100)
-        self.assertEqual(payment.vat_amount, 100)
+        self.assertEqual(payment.vat_amount, Decimal(100))
         payment = Payment(customer=customer, amount=100, amount_fixed=True)
-        self.assertEqual(payment.vat_amount, 100)
+        self.assertEqual(payment.vat_amount, Decimal(100))
         self.assertEqual(payment.amount_without_vat, 100)
+
+    def test_vat_calculation_rounding(self) -> None:
+        payment = Payment(customer=Customer(**CUSTOMER), amount=15)
+        self.assertEqual(payment.vat_amount, Decimal("18.15"))
+        self.assertEqual(int(payment.vat_amount * 100), 1815)
 
     def test_short_filename(self) -> None:
         customer = Customer()

--- a/weblate_web/tests.py
+++ b/weblate_web/tests.py
@@ -1651,7 +1651,7 @@ class PaymentsTest(FakturaceTestCase):
             )
             self.assertRedirects(response, url)
             self.assertContains(response, "Test payment")
-            self.assertContains(response, "€121.0")
+            self.assertContains(response, "€121")
             return payment, url, customer_url
 
     def test_view(self) -> None:


### PR DESCRIPTION
Avoid binary floating-point artifacts that could truncate VAT-inclusive gateway amounts by one cent.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
