### PR TITLE
fix(invoices): preserve EN 16931 monetary precision

### DIFF
--- a/weblate_web/crm/tests.py
+++ b/weblate_web/crm/tests.py
@@ -2101,7 +2101,7 @@ class CRMTestCase(BaseCRMTestCase):
             },
         )
         invoice = Invoice.objects.exclude(pk=invoice.pk).get()
-        self.assertEqual(invoice.total_amount, 513)
+        self.assertEqual(invoice.total_amount, Decimal("513.50"))
         self.assertRedirects(response, invoice.get_absolute_url())
 
         response = self.client.post(
@@ -2594,6 +2594,39 @@ class IncomeTrackingTestCase(BaseCRMTestCase):
         self.assertEqual(response.context["total_income"], Decimal(300))
         self.assertEqual(response.context["monthly_data"]["10"], Decimal(100))
         self.assertEqual(response.context["monthly_data"]["11"], Decimal(200))
+
+    def test_invoice_summary_rounding_stays_in_single_query(self) -> None:
+        issue_date = IncomeView.INVOICE_DATA_START
+        discount = Discount.objects.create(description="Half price", percents=50)
+        rounded_line = Invoice.objects.create(
+            kind=InvoiceKind.INVOICE,
+            category=InvoiceCategory.HOSTING,
+            customer=self.customer,
+            issue_date=issue_date,
+            currency=Currency.EUR,
+        )
+        rounded_line.invoiceitem_set.create(
+            description="Fractional-cent line", unit_price=Decimal("0.005")
+        )
+        discounted = Invoice.objects.create(
+            kind=InvoiceKind.INVOICE,
+            category=InvoiceCategory.HOSTING,
+            customer=self.customer,
+            issue_date=issue_date,
+            currency=Currency.EUR,
+            discount=discount,
+        )
+        discounted.invoiceitem_set.create(description="Discounted", unit_price=101)
+        with self.assertNumQueries(1):
+            rows = IncomeView()._get_invoice_summary_rows(  # pylint: disable=protected-access
+                year=issue_date.year,
+                month=issue_date.month,
+                period="month",
+            )
+
+        totals = {row["pk"]: row["total_no_vat"] for row in rows}
+        self.assertEqual(totals[rounded_line.pk], Decimal("0.01"))
+        self.assertEqual(totals[discounted.pk], Decimal("50.50"))
 
     def test_income_includes_only_processed_historical_payments(self):
         self.create_historical_payment(date(2023, 1, 1), 100)

--- a/weblate_web/crm/views.py
+++ b/weblate_web/crm/views.py
@@ -71,6 +71,7 @@ from weblate_web.invoices.models import (
     CURRENCY_MAP_FROM_PAYMENT,
     Currency,
     Invoice,
+    InvoiceCalculationVersion,
     InvoiceCategory,
     InvoiceKind,
     QuoteStatus,
@@ -587,7 +588,7 @@ class InvoiceDetailView(CRMMixin, DetailView[Invoice]):  # type: ignore[misc]
             )
             confirmed_at = timezone.now()
             payment = Payment.objects.create(
-                amount=int(self.object.total_amount),
+                amount=self.object.total_amount,
                 amount_fixed=True,
                 backend="manual",
                 currency=CURRENCY_MAP[cast("Currency", self.object.currency)],
@@ -1571,8 +1572,20 @@ class IncomeView(CRMMixin, TemplateView):  # type: ignore[misc]
     ) -> list[IncomeSummaryRow]:
         """Fetch per-invoice totals for the report using SQL aggregation."""
         zero = Value(Decimal(0), output_field=self.DECIMAL_OUTPUT_FIELD)
-        line_total = ExpressionWrapper(
+        raw_line_total = ExpressionWrapper(
             F("invoiceitem__unit_price") * F("invoiceitem__quantity"),
+            output_field=self.DECIMAL_OUTPUT_FIELD,
+        )
+        line_total = Case(
+            When(
+                calculation_version=InvoiceCalculationVersion.EN_16931,
+                then=Round(raw_line_total, precision=2),
+            ),
+            default=raw_line_total,
+            output_field=self.DECIMAL_OUTPUT_FIELD,
+        )
+        discount = ExpressionWrapper(
+            -F("positive_items_total") * F("discount__percents") / Value(100),
             output_field=self.DECIMAL_OUTPUT_FIELD,
         )
 
@@ -1611,15 +1624,12 @@ class IncomeView(CRMMixin, TemplateView):  # type: ignore[misc]
                     discount_amount=Case(
                         When(
                             discount__isnull=False,
-                            then=Round(
-                                ExpressionWrapper(
-                                    -F("positive_items_total")
-                                    * F("discount__percents")
-                                    / Value(100),
-                                    output_field=self.DECIMAL_OUTPUT_FIELD,
-                                ),
-                                precision=0,
-                            ),
+                            calculation_version=InvoiceCalculationVersion.LEGACY,
+                            then=Round(discount, precision=0),
+                        ),
+                        When(
+                            discount__isnull=False,
+                            then=Round(discount, precision=2),
                         ),
                         default=zero,
                         output_field=self.DECIMAL_OUTPUT_FIELD,

--- a/weblate_web/invoices/migrations/0003_invoice_calculation_version.py
+++ b/weblate_web/invoices/migrations/0003_invoice_calculation_version.py
@@ -1,0 +1,64 @@
+#
+# Copyright © Michal Čihař <michal@cihar.com>
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+def use_current_calculation_for_drafts(apps, _schema_editor):
+    Invoice = apps.get_model("invoices", "Invoice")
+    Payment = apps.get_model("payments", "Payment")
+    in_flight_drafts = Payment.objects.filter(
+        state__in=(2, 4), draft_invoice_id__isnull=False
+    ).values("draft_invoice_id")
+    Invoice.objects.filter(kind=0).exclude(pk__in=in_flight_drafts).update(
+        calculation_version=1
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("invoices", "0002_initial"),
+        ("payments", "0002_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="invoice",
+            name="calculation_version",
+            field=models.IntegerField(
+                choices=[(0, "Legacy"), (1, "EN 16931")],
+                default=0,
+                editable=False,
+            ),
+        ),
+        migrations.RunPython(
+            use_current_calculation_for_drafts, migrations.RunPython.noop
+        ),
+        migrations.AlterField(
+            model_name="invoice",
+            name="calculation_version",
+            field=models.IntegerField(
+                choices=[(0, "Legacy"), (1, "EN 16931")],
+                default=1,
+                editable=False,
+            ),
+        ),
+    ]

--- a/weblate_web/invoices/models.py
+++ b/weblate_web/invoices/models.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import datetime
 import uuid
 from dataclasses import dataclass
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from pathlib import Path
 from shutil import copyfile
 from typing import TYPE_CHECKING, Literal, cast
@@ -56,7 +56,6 @@ from pycheval import (
     TradeContact,
     TradeParty,
     generate_et,
-    generate_xml,
 )
 from pycheval.quantities import QuantityCode
 from pycheval.type_codes import DocumentTypeCode, PaymentMeansCode, TaxCategoryCode
@@ -88,6 +87,7 @@ if TYPE_CHECKING:
 INVOICES_URL = "invoices:"
 STATIC_URL = "static:"
 TEMPLATES_PATH = Path(__file__).parent / "templates"
+MONEY_QUANTUM = Decimal("0.01")
 
 
 def date_format(value: datetime.datetime | datetime.date) -> str:
@@ -102,6 +102,11 @@ def round_decimal(num: Decimal, max_decimals: int = 3) -> Decimal:
     if not num % Decimal("0.1"):
         return round(num, 1)
     return round(num, 2)
+
+
+def round_money(num: Decimal) -> Decimal:
+    """Round a document monetary amount to cents."""
+    return num.quantize(MONEY_QUANTUM, rounding=ROUND_HALF_UP)
 
 
 def url_fetcher(url: str) -> dict[str, str | bytes]:
@@ -276,6 +281,11 @@ class InvoiceKind(models.IntegerChoices):
         return InvoiceKind(int(value))
 
 
+class InvoiceCalculationVersion(models.IntegerChoices):
+    LEGACY = 0, "Legacy"
+    EN_16931 = 1, "EN 16931"
+
+
 class InvoiceCategory(models.IntegerChoices):
     HOSTING = 1, "Hosting"
     SUPPORT = 2, "Support"
@@ -316,6 +326,19 @@ class _EN16931TaxDetails:
     category: TaxCategoryCode
     rate: Decimal | None
     exemption_reason: str | None
+    money_s3_code: str
+
+
+@dataclass(frozen=True)
+class _InvoiceAmounts:
+    items: Decimal
+    positive_items: Decimal
+    discount: Decimal
+    line_total: Decimal
+    allowance_total: Decimal
+    tax_basis: Decimal
+    vat: Decimal
+    grand_total: Decimal
 
 
 class Discount(models.Model):
@@ -399,6 +422,11 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
         help_text="VAT rate in percents to apply on the invoice",
     )
     currency = models.IntegerField(choices=Currency, default=Currency.EUR)
+    calculation_version = models.IntegerField(
+        choices=InvoiceCalculationVersion,
+        default=InvoiceCalculationVersion.EN_16931,
+        editable=False,
+    )
 
     # Invoice chaining Proforma -> Invoice, or Draft -> Invoice
     parent = models.ForeignKey(
@@ -446,6 +474,7 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
         using=None,
         update_fields=None,
     ) -> None:
+        self.__dict__.pop("_amounts", None)
         if self.extra is None:
             self.extra = {}
         extra_fields: list[str] = []
@@ -483,6 +512,15 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
 
     def get_absolute_url(self) -> str:
         return reverse("crm:invoice-detail", kwargs={"pk": self.pk})
+
+    def clean(self) -> None:
+        super().clean()
+        if self.customer_id and self.kind in {
+            InvoiceKind.INVOICE,
+            InvoiceKind.PROFORMA,
+            InvoiceKind.QUOTE,
+        }:
+            self._get_en_16931_tax_details()
 
     def is_editable(self) -> bool:
         if self.kind == InvoiceKind.INVOICE:
@@ -524,67 +562,143 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
         """Exchange rate from currency to EUR."""
         return ExchangeRates.get("EUR", self.tax_date) / self.exchange_rate_czk
 
-    @cached_property
-    def total_items_amount(self) -> Decimal:
-        return sum(
-            (item.unit_price * item.quantity for item in self.all_items),
+    def _get_legacy_amounts(self) -> _InvoiceAmounts:
+        invoice_items = list(self.all_items)
+        raw_item_amounts = [item.unit_price * item.quantity for item in invoice_items]
+        items = sum(raw_item_amounts, start=Decimal(0))
+        positive_items = sum(
+            (amount for amount in raw_item_amounts if amount > 0),
             start=Decimal(0),
         )
-
-    @cached_property
-    def total_plus_items_amount(self) -> Decimal:
-        return sum(
+        negative_allowances = -sum(
             (
-                item.unit_price * item.quantity
-                for item in self.all_items
-                if item.unit_price > 0
+                item.total_price
+                for item, amount in zip(invoice_items, raw_item_amounts, strict=True)
+                if amount < 0
             ),
             start=Decimal(0),
         )
+        discount = (
+            round(positive_items * self.discount.percents / Decimal(100), 0)
+            if self.discount
+            else Decimal(0)
+        )
+        allowance_total = negative_allowances + discount
+        tax_basis = round_decimal(items - discount)
+        if not self.vat_rate:
+            vat = Decimal(0)
+        else:
+            vat = round_decimal(tax_basis * Decimal(self.vat_rate) / Decimal(100))
+        grand_total = round_decimal(tax_basis + vat, max_decimals=2)
+        return _InvoiceAmounts(
+            items=items,
+            positive_items=positive_items,
+            discount=discount,
+            line_total=tax_basis + allowance_total,
+            allowance_total=allowance_total,
+            tax_basis=tax_basis,
+            vat=vat,
+            grand_total=grand_total,
+        )
+
+    def _get_en_16931_amounts(self) -> _InvoiceAmounts:
+        item_amounts = [item.total_price for item in self.all_items]
+        items = sum(item_amounts, start=Decimal("0.00"))
+        positive_items = sum(
+            (amount for amount in item_amounts if amount > 0),
+            start=Decimal("0.00"),
+        )
+        negative_allowances = -sum(
+            (amount for amount in item_amounts if amount < 0),
+            start=Decimal("0.00"),
+        )
+        discount = (
+            round_money(positive_items * self.discount.percents / Decimal(100))
+            if self.discount
+            else Decimal("0.00")
+        )
+        allowance_total = negative_allowances + discount
+        tax_basis = round_money(positive_items - allowance_total)
+        if not self.vat_rate:
+            vat = Decimal("0.00")
+            grand_total = tax_basis
+        else:
+            vat = round_money(tax_basis * Decimal(self.vat_rate) / Decimal(100))
+            grand_total = tax_basis + vat
+        return _InvoiceAmounts(
+            items=items,
+            positive_items=positive_items,
+            discount=discount,
+            line_total=positive_items,
+            allowance_total=allowance_total,
+            tax_basis=tax_basis,
+            vat=vat,
+            grand_total=grand_total,
+        )
 
     @cached_property
+    def _amounts(self) -> _InvoiceAmounts:
+        if self.calculation_version == InvoiceCalculationVersion.LEGACY:
+            return self._get_legacy_amounts()
+        return self._get_en_16931_amounts()
+
+    @property
+    def total_items_amount(self) -> Decimal:
+        return self._amounts.items
+
+    @property
+    def total_plus_items_amount(self) -> Decimal:
+        return self._amounts.positive_items
+
+    @property
     def total_discount(self) -> Decimal:
-        if not self.discount:
-            return Decimal(0)
-        return round(-self.total_plus_items_amount * self.discount.percents / 100, 0)
+        return -self._amounts.discount
 
     @property
     def display_total_discount(self) -> str:
         return self.render_amount(self.total_discount)
 
-    @cached_property
+    @property
     def total_amount_no_vat(self) -> Decimal:
-        return round_decimal(self.total_items_amount + self.total_discount)
+        return self._amounts.tax_basis
 
     @property
     def total_amount_no_vat_czk(self) -> Decimal:
-        return round(self.total_amount_no_vat * self.exchange_rate_czk, 2)
+        if self.calculation_version == InvoiceCalculationVersion.LEGACY:
+            return round(self.total_amount_no_vat * self.exchange_rate_czk, 2)
+        return round_money(self.total_amount_no_vat * self.exchange_rate_czk)
 
     @property
     def display_total_amount_no_vat(self) -> str:
         return self.render_amount(self.total_amount_no_vat)
 
-    @cached_property
+    @property
     def total_vat(self) -> Decimal:
-        if not self.vat_rate:
-            return Decimal(0)
-        return round_decimal(self.total_amount_no_vat * self.vat_rate / 100)
+        return self._amounts.vat
 
     @property
     def total_vat_czk(self) -> Decimal:
-        return round_decimal(self.total_vat * self.exchange_rate_czk, max_decimals=2)
+        if self.calculation_version == InvoiceCalculationVersion.LEGACY:
+            return round_decimal(
+                self.total_vat * self.exchange_rate_czk, max_decimals=2
+            )
+        return round_money(self.total_vat * self.exchange_rate_czk)
 
     @property
     def display_total_vat(self) -> str:
         return self.render_amount(self.total_vat)
 
-    @cached_property
+    @property
     def total_amount(self) -> Decimal:
-        return round_decimal(self.total_amount_no_vat + self.total_vat, max_decimals=2)
+        return self._amounts.grand_total
 
     @property
     def total_amount_czk(self) -> Decimal:
-        return round_decimal(self.total_amount * self.exchange_rate_czk, max_decimals=2)
+        if self.calculation_version == InvoiceCalculationVersion.LEGACY:
+            return round_decimal(
+                self.total_amount * self.exchange_rate_czk, max_decimals=2
+            )
+        return round_money(self.total_amount * self.exchange_rate_czk)
 
     @property
     def display_total_amount(self) -> str:
@@ -697,6 +811,8 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
         return settings.INVOICES_PATH / self.get_filename("einvoice.xml")
 
     def generate_files(self) -> None:
+        # Validate accounting data before any document is written.
+        self._get_en_16931_tax_details()
         self.generate_money_s3_xml()
         self.generate_en_16931_xml()
         self.generate_pdf()
@@ -718,6 +834,7 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
 
     def get_money_s3_xml_tree(self, invoices: etree._Element) -> None:  # ruff:ignore[too-many-statements, complex-structure]
         """Create XML tree for Money S3 invoice XML."""
+        tax_details = self._get_en_16931_tax_details()
 
         def add_element(root, name: str, text: str | Decimal | int | None = None):
             added = etree.SubElement(root, name)
@@ -765,12 +882,7 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
         add_element(output, "PlnenoDPH", self.tax_date.isoformat())
         add_element(output, "Splatno", self.due_date.isoformat())
         add_element(output, "DatSkPoh", self.tax_date.isoformat())
-        if self.customer.country == "CZ" or self.vat_rate:
-            add_element(output, "KodDPH", "19Ř01,02")
-        elif self.customer.is_eu:
-            add_element(output, "KodDPH", "19Ř21")
-        else:
-            add_element(output, "KodDPH", "19Ř26")
+        add_element(output, "KodDPH", tax_details.money_s3_code)
         add_element(output, "ZjednD", "0")
         add_element(output, "VarSymbol", self.number)
 
@@ -866,12 +978,26 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
                 category=TaxCategoryCode.STANDARD_RATE,
                 rate=Decimal(self.vat_rate),
                 exemption_reason=None,
+                money_s3_code="19Ř01,02",
+            )
+        if self.customer.country_code == "CZ":
+            raise ValidationError(
+                {"vat_rate": gettext("Czech invoices cannot use a zero VAT rate.")}
             )
         if self.customer.is_eu:
+            if not self.customer.vat:
+                raise ValidationError(
+                    {
+                        "vat_rate": gettext(
+                            "EU reverse-charge invoices require a buyer VAT ID."
+                        )
+                    }
+                )
             return _EN16931TaxDetails(
                 category=TaxCategoryCode.REVERSE_CHARGE,
                 rate=Decimal(0),
                 exemption_reason="Reverse charge",
+                money_s3_code="19Ř21",
             )
         return _EN16931TaxDetails(
             category=TaxCategoryCode.OUT_OF_SCOPE,
@@ -879,9 +1005,10 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
             exemption_reason=(
                 "Not subject to VAT because the place of supply is outside the EU"
             ),
+            money_s3_code="19Ř26",
         )
 
-    def get_en_16931_xml(self) -> EN16931Invoice:
+    def get_en_16931_xml(self) -> EN16931Invoice:  # ruff:ignore[too-many-locals]
         if self.kind == InvoiceKind.INVOICE:
             type_code = DocumentTypeCode.INVOICE
         elif self.kind == InvoiceKind.PROFORMA:
@@ -891,10 +1018,11 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
 
         total_amount = Money(self.total_amount, self.get_currency_display())
 
-        # Ensure tax has two decimals, see https://github.com/zfutura/pycheval/issues/30
-        tax_amount = Money(
-            self.total_vat.quantize(Decimal("0.01")), self.get_currency_display()
-        )
+        tax_value = self.total_vat
+        if self.calculation_version == InvoiceCalculationVersion.LEGACY:
+            # Legacy documents quantized the VAT only for Factur-X output.
+            tax_value = tax_value.quantize(MONEY_QUANTUM)
+        tax_amount = Money(tax_value, self.get_currency_display())
         tax_basis_amount = Money(self.total_amount_no_vat, self.get_currency_display())
 
         tax_details = self._get_en_16931_tax_details()
@@ -904,16 +1032,15 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
             basis_amount=tax_basis_amount,
             rate_percent=tax_details.rate,
             exemption_reason=tax_details.exemption_reason,
+            tax_point_date=self.tax_date if self.is_final else None,
         )
 
         line_items: list[EN16931LineItem] = []
         allowances: list[DocumentAllowance] = []
-
-        line_total_amount = Money(
-            self.total_amount_no_vat - self.total_discount, self.get_currency_display()
-        )
+        amounts = self._amounts
+        line_total_amount = Money(amounts.line_total, self.get_currency_display())
         allowance_total_amount = Money(
-            -self.total_discount, self.get_currency_display()
+            amounts.allowance_total, self.get_currency_display()
         )
 
         for item in self.all_items:
@@ -929,17 +1056,15 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
                         tax_category=tax_details.category,
                     )
                 )
-                line_total_amount.amount -= item.total_price
-                allowance_total_amount.amount -= item.total_price
             else:
+                net_price = item.unit_price
+                if self.calculation_version == InvoiceCalculationVersion.LEGACY:
+                    net_price = item.total_price / item.quantity
                 line_items.append(
                     EN16931LineItem(
                         id=item.package.name if item.package else f"ITEM-{item.id}",
                         name=item.description,
-                        net_price=Money(
-                            item.total_price / item.quantity,
-                            self.get_currency_display(),
-                        ),
+                        net_price=Money(net_price, self.get_currency_display()),
                         billed_quantity=(
                             Decimal(item.quantity),
                             QuantityCode.HOUR
@@ -1068,15 +1193,27 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
             tax=[tax],
         )
 
+    def get_en_16931_xml_tree(self) -> ElementTree.Element[str]:
+        """Generate schema-compatible EN 16931 XML."""
+        xml_tree = generate_et(self.get_en_16931_xml())
+        # pycheval 0.3.3 emits DateTimeString here, but the CII schema uses
+        # DateString for ApplicableTradeTax/TaxPointDate.
+        # Reported at https://github.com/zfutura/pycheval/issues/64
+        # TODO: Use pycheval.generate_xml once this is fixed
+        for tax_point in xml_tree.iter("ram:TaxPointDate"):
+            date_element = tax_point.find("udt:DateTimeString")
+            if date_element is not None:
+                date_element.tag = "udt:DateString"
+        return xml_tree
+
+    def get_en_16931_xml_string(self) -> str:
+        xml_tree = self.get_en_16931_xml_tree()
+        ElementTree.indent(xml_tree)
+        return ElementTree.tostring(xml_tree, encoding="unicode", xml_declaration=True)
+
     def generate_en_16931_xml(self) -> None:
         if self.supports_en_16931:
-            invoice = self.get_en_16931_xml()
-            xml_tree = generate_et(invoice)
-            ElementTree.indent(xml_tree)
-            xml_string = ElementTree.tostring(
-                xml_tree, encoding="unicode", xml_declaration=True
-            )
-            self.en_16931_xml_path.write_text(xml_string)
+            self.en_16931_xml_path.write_text(self.get_en_16931_xml_string())
 
     def _generate_pdf(
         self,
@@ -1104,7 +1241,7 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
         if self.supports_en_16931:
             attachments = [
                 Attachment(
-                    string=generate_xml(self.get_en_16931_xml()),
+                    string=self.get_en_16931_xml_string(),
                     base_url="factur-x.xml",
                     description="Factur-x invoice",
                 )
@@ -1136,6 +1273,7 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
             discount=self.discount,
             vat_rate=self.vat_rate,
             currency=self.currency,
+            calculation_version=self.calculation_version,
             tax_date=cast("datetime.date", tax_date),
             parent=self,
             prepaid=prepaid,
@@ -1169,7 +1307,8 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
         if not self.can_be_paid(InvoiceKind.DRAFT):
             raise ValueError("Payment already exists for this invoice!")
         return self.draft_payment_set.create(
-            amount=int(self.total_amount),
+            amount=self.total_amount,
+            requested_amount=self.total_amount,
             amount_fixed=True,
             description=self.get_description(),
             recurring=recurring,
@@ -1384,13 +1523,24 @@ class InvoiceItem(models.Model):
 
     @property
     def total_price(self) -> Decimal:
-        return round_decimal(self.unit_price * self.quantity)
+        amount = self.unit_price * self.quantity
+        if self.invoice.calculation_version == InvoiceCalculationVersion.LEGACY:
+            return round_decimal(amount)
+        return round_money(amount)
 
     @cached_property
     def total_vat(self) -> Decimal:
         if not self.invoice.vat_rate:
-            return Decimal(0)
-        return round_decimal(self.total_price * self.invoice.vat_rate / 100)
+            if self.invoice.calculation_version == InvoiceCalculationVersion.LEGACY:
+                return Decimal(0)
+            return Decimal("0.00")
+        if self.invoice.calculation_version == InvoiceCalculationVersion.LEGACY:
+            return round_decimal(
+                self.total_price * Decimal(self.invoice.vat_rate) / Decimal(100)
+            )
+        return round_money(
+            self.total_price * Decimal(self.invoice.vat_rate) / Decimal(100)
+        )
 
     @cached_property
     def total_vat_price(self) -> Decimal:

--- a/weblate_web/invoices/tests.py
+++ b/weblate_web/invoices/tests.py
@@ -3,30 +3,34 @@ from __future__ import annotations
 import os
 from datetime import date, timedelta
 from decimal import Decimal
+from importlib import import_module
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import cast
 from unittest.mock import patch
 
 import requests
 import responses
+from django.apps import apps
 from django.core.exceptions import ValidationError
+from django.forms import modelform_factory
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.translation import override
 from drafthorse.utils import validate_xml  # type: ignore[import-untyped]
 from lxml import etree
-from pycheval import generate_xml
 from pycheval.quantities import QuantityCode
 from pycheval.type_codes import TaxCategoryCode
 
 from weblate_web.models import Package, PackageCategory
-from weblate_web.payments.models import Customer
+from weblate_web.payments.models import Customer, Payment
 from weblate_web.tests import UserTestCase, cnb_mock_rates, mock_vies
 
 from .models import (
     Currency,
     Discount,
     Invoice,
+    InvoiceCalculationVersion,
     InvoiceCategory,
     InvoiceKind,
     QuantityUnit,
@@ -39,7 +43,7 @@ S3_SCHEMA_PATH = (
 S3_SCHEMA = etree.XMLSchema(etree.parse(S3_SCHEMA_PATH))
 
 
-class InvoiceTestCase(UserTestCase):
+class InvoiceTestCase(UserTestCase):  # ruff:ignore[too-many-public-methods]
     def create_customer(
         self,
         *,
@@ -47,7 +51,7 @@ class InvoiceTestCase(UserTestCase):
         contact_point: str = "",
         email: str = "",
         accounting_reference: str = "",
-        country: str = "cz",
+        country: str = "DE",
     ) -> Customer:
         return Customer.objects.create(
             name="Zkušební zákazník",
@@ -72,7 +76,7 @@ class InvoiceTestCase(UserTestCase):
         customer_contact_point: str = "",
         customer_email: str = "",
         accounting_reference: str = "",
-        country: str = "cz",
+        country: str = "DE",
         vat: str = "",
         kind: InvoiceKind = InvoiceKind.INVOICE,
         currency: Currency = Currency.EUR,
@@ -80,9 +84,9 @@ class InvoiceTestCase(UserTestCase):
         due_date: date | None = None,
         prepaid: bool = False,
     ) -> Invoice:
-        if vat_rate == 0 and not vat:
+        if vat_rate == 0 and not vat and country.upper() == "DE":
             # Ensure VAT ID is present for invoices without VAT
-            vat = "CZ21668027"
+            vat = "DE123456789"
         return Invoice.objects.create(
             customer=self.create_customer(
                 vat=vat,
@@ -129,12 +133,12 @@ class InvoiceTestCase(UserTestCase):
         customer_contact_point: str = "",
         customer_email: str = "",
         accounting_reference: str = "",
-        country: str = "cz",
+        country: str = "DE",
         vat: str = "",
         kind: InvoiceKind = InvoiceKind.INVOICE,
         tax_date: date | None = None,
         due_date: date | None = None,
-        unit_price: int = 100,
+        unit_price: int | Decimal = 100,
         prepaid: bool = False,
     ) -> Invoice:
         invoice = self.create_invoice_base(
@@ -217,7 +221,7 @@ class InvoiceTestCase(UserTestCase):
             self.assertEqual(result["result"], "SUCCESS", result["reports"])
 
     def get_einvoice_xml_tree(self, invoice: Invoice) -> etree._Element:
-        return etree.fromstring(generate_xml(invoice.get_en_16931_xml()).encode())
+        return etree.fromstring(invoice.get_en_16931_xml_string().encode())
 
     def get_money_s3_xml_tree(self, invoice: Invoice) -> etree._Element:
         document, invoices = invoice.get_invoice_xml_root()
@@ -312,7 +316,7 @@ class InvoiceTestCase(UserTestCase):
             {allowance.tax_rate for allowance in einvoice.allowances}, {None}
         )
 
-        xml = generate_xml(einvoice).encode()
+        xml = invoice.get_en_16931_xml_string().encode()
         validate_xml(xml, "FACTUR-X_EN16931")
         root = etree.fromstring(xml)
         namespaces = EN16931Validator().namespaces
@@ -342,6 +346,168 @@ class InvoiceTestCase(UserTestCase):
             root.xpath(".//ram:CalculatedAmount/text()", namespaces=namespaces),
             ["0.00"],
         )
+
+    def test_invalid_zero_vat_states_are_rejected_before_generation(self) -> None:
+        cases = (
+            ("CZ", "CZ21668027"),
+            ("DE", ""),
+        )
+        for country, vat in cases:
+            with (
+                self.subTest(country=country),
+                TemporaryDirectory() as temp_dir,
+                override_settings(INVOICES_PATH=Path(temp_dir)),
+            ):
+                invoice = self.create_invoice(country=country, vat=vat)
+                if not vat:
+                    invoice.customer.vat = ""
+                    invoice.customer.save(update_fields=["vat"])
+
+                with self.assertRaises(ValidationError):
+                    invoice.full_clean()
+                with self.assertRaises(ValidationError):
+                    invoice.generate_files()
+
+                self.assertFalse(invoice.xml_path.exists())
+                self.assertFalse(invoice.en_16931_xml_path.exists())
+                self.assertFalse(invoice.path.exists())
+
+    def test_draft_validation_allows_incomplete_tax_state(self) -> None:
+        invoice = self.create_invoice(
+            country="CZ", vat="CZ21668027", kind=InvoiceKind.DRAFT
+        )
+
+        invoice.full_clean()
+        with self.assertRaises(ValidationError):
+            invoice.generate_files()
+
+    def test_quote_validation_rejects_incomplete_tax_state(self) -> None:
+        invoice = self.create_invoice(country="FR", kind=InvoiceKind.QUOTE)
+
+        with self.assertRaises(ValidationError):
+            invoice.full_clean()
+        with self.assertRaises(ValidationError):
+            invoice.generate_files()
+
+    def test_validation_without_customer_reports_field_error(self) -> None:
+        invoice_form = modelform_factory(
+            Invoice,
+            fields=("kind", "category", "customer", "vat_rate", "currency"),
+        )
+        form = invoice_form(
+            data={
+                "kind": InvoiceKind.INVOICE,
+                "category": InvoiceCategory.HOSTING,
+                "customer": "",
+                "vat_rate": 0,
+                "currency": Currency.EUR,
+            }
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("customer", form.errors)
+
+    def test_tax_point_date_is_exported_only_for_final_invoice(self) -> None:
+        tax_date = date(2025, 6, 30)
+        final_invoice = self.create_invoice(vat_rate=21, tax_date=tax_date)
+        proforma = self.create_invoice(
+            vat_rate=21, tax_date=tax_date, kind=InvoiceKind.PROFORMA
+        )
+        namespaces = EN16931Validator().namespaces
+
+        final_root = self.get_einvoice_xml_tree(final_invoice)
+        self.assertEqual(
+            final_root.xpath(
+                ".//ram:TaxPointDate/udt:DateString/text()",
+                namespaces=namespaces,
+            ),
+            ["20250630"],
+        )
+        proforma_root = self.get_einvoice_xml_tree(proforma)
+        self.assertEqual(
+            proforma_root.xpath(".//ram:TaxPointDate", namespaces=namespaces), []
+        )
+
+    def test_validator_rejects_three_decimal_monetary_amounts(self) -> None:
+        root = self.get_einvoice_xml_tree(self.create_invoice(vat_rate=21))
+        namespaces = EN16931Validator().namespaces
+        mutations = (
+            (
+                (
+                    ".//ram:SpecifiedTradeSettlementLineMonetarySummation/"
+                    "ram:LineTotalAmount"
+                ),
+                "BR-DEC-23",
+            ),
+            (
+                (
+                    ".//ram:SpecifiedTradeSettlementHeaderMonetarySummation/"
+                    "ram:LineTotalAmount"
+                ),
+                "BR-DEC-09",
+            ),
+            (
+                (
+                    ".//ram:SpecifiedTradeSettlementHeaderMonetarySummation/"
+                    "ram:TaxBasisTotalAmount"
+                ),
+                "BR-DEC-12",
+            ),
+        )
+        for xpath, expected_rule in mutations:
+            with self.subTest(rule=expected_rule):
+                mutated = etree.fromstring(etree.tostring(root))
+                element = mutated.find(xpath, namespaces)
+                self.assertIsNotNone(element)
+                if element is None:
+                    self.fail(f"Missing test element for {expected_rule}")
+                element.text = "100.001"
+
+                is_valid, errors, _warnings = EN16931Validator().validate_bytes(
+                    etree.tostring(mutated)
+                )
+
+                self.assertFalse(is_valid)
+                self.assertIn(expected_rule, {error.rule for error in errors})
+
+    def test_validator_rejects_incomplete_reverse_charge(self) -> None:
+        invoice = self.create_invoice(
+            discount=Discount.objects.create(
+                description="Reverse charge discount", percents=10
+            )
+        )
+        root = self.get_einvoice_xml_tree(invoice)
+        namespaces = EN16931Validator().namespaces
+        buyer_vat = root.find(
+            ".//ram:BuyerTradeParty/ram:SpecifiedTaxRegistration/"
+            "ram:ID[@schemeID='VA']",
+            namespaces,
+        )
+        exemption_reason = root.find(
+            ".//ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax/"
+            "ram:ExemptionReason",
+            namespaces,
+        )
+        self.assertIsNotNone(buyer_vat)
+        self.assertIsNotNone(exemption_reason)
+        if buyer_vat is None or exemption_reason is None:
+            self.fail("Generated reverse-charge test data is incomplete")
+        buyer_vat_parent = buyer_vat.getparent()
+        exemption_reason_parent = exemption_reason.getparent()
+        if buyer_vat_parent is None or exemption_reason_parent is None:
+            self.fail("Generated reverse-charge elements have no parent")
+        buyer_vat_parent.remove(buyer_vat)
+        exemption_reason_parent.remove(exemption_reason)
+
+        is_valid, errors, _warnings = EN16931Validator().validate_bytes(
+            etree.tostring(root)
+        )
+
+        self.assertFalse(is_valid)
+        rules = {error.rule for error in errors}
+        required_rules = {"BR-AE-02", "BR-AE-03", "BR-AE-04"}
+        self.assertSetEqual(required_rules & rules, required_rules)
+        self.assertIn("BR-AE-10", rules)
 
     def test_customer_reference_is_buyer_order_reference(self) -> None:
         invoice = self.create_invoice(customer_reference="PO123456")
@@ -513,6 +679,61 @@ class InvoiceTestCase(UserTestCase):
         self.assertEqual(invoice.total_amount, 121)
         self.validate_invoice(invoice)
 
+    def test_amounts_are_calculated_once(self) -> None:
+        invoice = self.create_invoice(vat_rate=21)
+
+        with patch.object(
+            invoice,
+            "_get_en_16931_amounts",
+            wraps=invoice._get_en_16931_amounts,  # pylint: disable=protected-access
+        ) as calculate_amounts:
+            self.assertEqual(invoice.total_amount_no_vat, 100)
+            self.assertEqual(invoice.total_vat, 21)
+            self.assertEqual(invoice.total_amount, 121)
+
+        calculate_amounts.assert_called_once_with()
+
+    def test_half_up_vat_rounding_is_shared_by_all_formats(self) -> None:
+        invoice = self.create_invoice(vat_rate=21, unit_price=Decimal("0.50"))
+
+        self.assertEqual(invoice.total_amount_no_vat, Decimal("0.50"))
+        self.assertEqual(invoice.total_vat, Decimal("0.11"))
+        self.assertEqual(invoice.total_amount, Decimal("0.61"))
+        self.assertIn("€0.11", invoice.render_html())
+
+        einvoice = invoice.get_en_16931_xml()
+        self.assertEqual(einvoice.tax_basis_total_amount.amount, Decimal("0.50"))
+        self.assertEqual(einvoice.tax_total_amounts[0].amount, Decimal("0.11"))
+        self.assertEqual(einvoice.grand_total_amount.amount, Decimal("0.61"))
+
+        money_s3 = self.get_money_s3_xml_tree(invoice)
+        self.assertEqual(money_s3.findtext(".//Valuty/SouhrnDPH/Zaklad22"), "0.50")
+        self.assertEqual(money_s3.findtext(".//Valuty/SouhrnDPH/DPH22"), "0.11")
+        self.assertEqual(money_s3.findtext(".//Valuty/Celkem"), "0.61")
+
+    def test_linked_payment_does_not_change_invoice_amounts(self) -> None:
+        invoice = self.create_invoice(
+            vat_rate=21, unit_price=Decimal("50.00"), prepaid=True
+        )
+        Payment.objects.create(
+            amount=60,
+            amount_fixed=True,
+            customer=invoice.customer,
+            currency=Payment.CURRENCY_EUR,
+            description="Legacy truncated payment",
+            paid_invoice=invoice,
+            state=Payment.PROCESSED,
+        )
+
+        self.assertEqual(invoice.total_amount_no_vat, Decimal("50.00"))
+        self.assertEqual(invoice.total_vat, Decimal("10.50"))
+        self.assertEqual(invoice.total_amount, Decimal("60.50"))
+        xml = invoice.get_en_16931_xml_string().encode()
+        validate_xml(xml, "FACTUR-X_EN16931")
+        is_valid, errors, warnings = EN16931Validator().validate_bytes(xml)
+        self.assertTrue(is_valid, errors)
+        self.assertEqual(warnings, [])
+
     @responses.activate
     def test_total_vat_note(self) -> None:
         self.mock_requests()
@@ -570,6 +791,71 @@ class InvoiceTestCase(UserTestCase):
         )
         self.assertEqual(invoice.total_amount, 50)
         self.validate_invoice(invoice)
+
+    def test_legacy_discount_rounding_is_preserved(self) -> None:
+        discount = Discount.objects.create(description="Legacy discount", percents=50)
+        invoice = self.create_invoice(discount=discount, unit_price=Decimal(101))
+        self.assertEqual(invoice.total_amount, Decimal("50.50"))
+
+        invoice.calculation_version = InvoiceCalculationVersion.LEGACY
+        invoice.save(update_fields=["calculation_version"])
+        self.assertEqual(invoice.total_discount, Decimal(-50))
+        self.assertEqual(invoice.total_amount_no_vat, Decimal(51))
+        self.assertEqual(invoice.total_amount, Decimal(51))
+
+        einvoice = invoice.get_en_16931_xml()
+        allowance_total = einvoice.allowance_total_amount
+        if allowance_total is None:
+            self.fail("Legacy discount invoice has no allowance total")
+        self.assertEqual(allowance_total.amount, Decimal(50))
+        self.assertEqual(einvoice.tax_basis_total_amount.amount, Decimal(51))
+        self.assertEqual(einvoice.grand_total_amount.amount, Decimal(51))
+
+    def test_draft_migration_preserves_in_flight_calculation(self) -> None:
+        in_flight = self.create_invoice(kind=InvoiceKind.DRAFT)
+        convertible = self.create_invoice(kind=InvoiceKind.DRAFT)
+        Invoice.objects.filter(pk__in=(in_flight.pk, convertible.pk)).update(
+            calculation_version=InvoiceCalculationVersion.LEGACY
+        )
+        Payment.objects.create(
+            amount=100,
+            customer=in_flight.customer,
+            description="In-flight draft",
+            draft_invoice=in_flight,
+            state=Payment.PENDING,
+        )
+
+        migration = import_module(
+            "weblate_web.invoices.migrations.0003_invoice_calculation_version"
+        )
+        migration.use_current_calculation_for_drafts(apps, None)
+
+        in_flight.refresh_from_db()
+        convertible.refresh_from_db()
+        self.assertEqual(
+            in_flight.calculation_version, InvoiceCalculationVersion.LEGACY
+        )
+        self.assertEqual(
+            convertible.calculation_version, InvoiceCalculationVersion.EN_16931
+        )
+
+    def test_duplicate_preserves_calculation_version(self) -> None:
+        discount = Discount.objects.create(description="Proforma discount", percents=50)
+        proforma = self.create_invoice(
+            discount=discount,
+            kind=InvoiceKind.PROFORMA,
+            unit_price=Decimal(101),
+        )
+        proforma.calculation_version = InvoiceCalculationVersion.LEGACY
+        proforma.save(update_fields=["calculation_version"])
+
+        invoice = proforma.duplicate(
+            kind=InvoiceKind.INVOICE,
+            tax_date=proforma.tax_date,
+        )
+
+        self.assertEqual(invoice.calculation_version, InvoiceCalculationVersion.LEGACY)
+        self.assertEqual(invoice.total_amount, Decimal(51))
 
     @responses.activate
     def test_discount_negative(self) -> None:

--- a/weblate_web/invoices/validation.py
+++ b/weblate_web/invoices/validation.py
@@ -8,6 +8,7 @@ EN 16931 Invoice XML Validator.
 
 import re
 from datetime import datetime
+from decimal import Decimal, InvalidOperation
 
 from lxml import etree
 
@@ -86,6 +87,7 @@ class EN16931Validator:
 
         # Validate seller and buyer
         self._validate_seller_buyer_cii(transaction)
+        self._validate_reverse_charge_cii(transaction)
 
         # Validate invoice lines
         lines = transaction.findall(
@@ -189,20 +191,35 @@ class EN16931Validator:
                 )
             )
 
-    def _get_decimal(self, element) -> float:
+    def _get_decimal(self, element) -> Decimal:
         """Safely extract decimal value from element."""
         if element is None or not element.text:
-            return 0.0
+            return Decimal(0)
         try:
-            return float(element.text)
-        except (ValueError, TypeError):
-            return 0.0
+            return Decimal(element.text)
+        except (InvalidOperation, TypeError):
+            return Decimal(0)
 
     def _amounts_equal(
-        self, amount1: float, amount2: float, tolerance: float = 0.02
+        self,
+        amount1: Decimal,
+        amount2: Decimal,
+        tolerance: Decimal = Decimal("0.02"),
     ) -> bool:
         """Check if two amounts are equal within a tolerance (for rounding differences)."""
         return abs(amount1 - amount2) < tolerance
+
+    def _validate_decimal_places(self, element, rule: str, field_name: str) -> None:
+        if element is None or not element.text:
+            return
+        fraction = element.text.partition(".")[2]
+        if len(fraction) > 2:
+            self.errors.append(
+                ValidationError(
+                    rule,
+                    f"{field_name} must have no more than two decimal places",
+                )
+            )
 
     def _validate_seller_buyer_cii(self, transaction):
         """Validate seller and buyer information for CII format."""
@@ -280,6 +297,91 @@ class EN16931Validator:
                 else:
                     self._validate_country_code(country.text, "BT-55")
 
+    def _validate_reverse_charge_cii(self, transaction) -> None:
+        line_taxes = transaction.xpath(
+            "./ram:IncludedSupplyChainTradeLineItem/"
+            "ram:SpecifiedLineTradeSettlement/ram:ApplicableTradeTax"
+            "[ram:CategoryCode='AE']",
+            namespaces=self.namespaces,
+        )
+        allowance_taxes = transaction.xpath(
+            "./ram:ApplicableHeaderTradeSettlement/"
+            "ram:SpecifiedTradeAllowanceCharge/ram:CategoryTradeTax"
+            "[ram:CategoryCode='AE']",
+            namespaces=self.namespaces,
+        )
+        breakdown_taxes = transaction.xpath(
+            "./ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax"
+            "[ram:CategoryCode='AE']",
+            namespaces=self.namespaces,
+        )
+        tax_groups = (
+            ("BR-AE-02", line_taxes),
+            ("BR-AE-03", allowance_taxes),
+            ("BR-AE-04", breakdown_taxes),
+        )
+        if not any(taxes for _, taxes in tax_groups):
+            return
+
+        seller_ids = transaction.xpath(
+            "./ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/"
+            "ram:SpecifiedTaxRegistration/ram:ID[@schemeID='VA' or @schemeID='FC']"
+            " | ./ram:ApplicableHeaderTradeAgreement/"
+            "ram:SellerTaxRepresentativeTradeParty/ram:SpecifiedTaxRegistration/"
+            "ram:ID[@schemeID='VA']",
+            namespaces=self.namespaces,
+        )
+        buyer_ids = transaction.xpath(
+            "./ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/"
+            "ram:SpecifiedTaxRegistration/ram:ID[@schemeID='VA']"
+            " | ./ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/"
+            "ram:SpecifiedLegalOrganization/ram:ID",
+            namespaces=self.namespaces,
+        )
+        has_seller_id = any(element.text for element in seller_ids)
+        has_buyer_id = any(element.text for element in buyer_ids)
+        for rule, taxes in tax_groups:
+            if taxes and (not has_seller_id or not has_buyer_id):
+                self.errors.append(
+                    ValidationError(
+                        rule,
+                        "Reverse charge requires seller and buyer tax or legal identifiers",
+                    )
+                )
+
+        for rule, taxes in (
+            ("BR-AE-05", line_taxes),
+            ("BR-AE-06", allowance_taxes),
+            ("BR-AE-07", breakdown_taxes),
+        ):
+            for tax in taxes:
+                rate = tax.find("ram:RateApplicablePercent", self.namespaces)
+                if rate is None or self._get_decimal(rate) != 0:
+                    self.errors.append(
+                        ValidationError(rule, "Reverse-charge VAT rate must be zero")
+                    )
+
+        for tax in breakdown_taxes:
+            calculated = tax.find("ram:CalculatedAmount", self.namespaces)
+            if calculated is None or self._get_decimal(calculated) != 0:
+                self.errors.append(
+                    ValidationError(
+                        "BR-AE-09", "Reverse-charge VAT amount must be zero"
+                    )
+                )
+            reason = tax.find("ram:ExemptionReason", self.namespaces)
+            reason_code = tax.find("ram:ExemptionReasonCode", self.namespaces)
+            if not (
+                (reason is not None and reason.text)
+                or (reason_code is not None and reason_code.text)
+            ):
+                self.errors.append(
+                    ValidationError(
+                        "BR-AE-10",
+                        "Reverse charge requires a VAT exemption reason or code",
+                    )
+                )
+
     def _validate_country_code(self, code: str, bt_code: str):
         """Validate ISO 3166-1 alpha-2 country code."""
         if not re.match(r"^[A-Z]{2}$", code):
@@ -339,6 +441,12 @@ class EN16931Validator:
                             "BR-24",
                             f"Line {line_num}: Line net amount (BT-131) is mandatory",
                         )
+                    )
+                else:
+                    self._validate_decimal_places(
+                        line_amount,
+                        "BR-DEC-23",
+                        f"Line {line_num} net amount (BT-131)",
                     )
 
         # BR-26: Item name
@@ -500,6 +608,39 @@ class EN16931Validator:
                 ValidationError("BR-15", "Amount due for payment (BT-115) is mandatory")
             )
 
+        for element, rule, field_name in (
+            (line_total, "BR-DEC-09", "Sum of line net amounts (BT-106)"),
+            (
+                monetary.find(".//ram:AllowanceTotalAmount", self.namespaces),
+                "BR-DEC-10",
+                "Sum of allowances (BT-107)",
+            ),
+            (
+                monetary.find(".//ram:ChargeTotalAmount", self.namespaces),
+                "BR-DEC-11",
+                "Sum of charges (BT-108)",
+            ),
+            (tax_basis_total, "BR-DEC-12", "Invoice total without VAT (BT-109)"),
+            (grand_total, "BR-DEC-14", "Invoice total with VAT (BT-112)"),
+            (
+                monetary.find(".//ram:TotalPrepaidAmount", self.namespaces),
+                "BR-DEC-16",
+                "Paid amount (BT-113)",
+            ),
+            (
+                monetary.find(".//ram:RoundingAmount", self.namespaces),
+                "BR-DEC-17",
+                "Rounding amount (BT-114)",
+            ),
+            (due_payable, "BR-DEC-18", "Amount due for payment (BT-115)"),
+        ):
+            self._validate_decimal_places(element, rule, field_name)
+
+        for tax_total in monetary.findall(".//ram:TaxTotalAmount", self.namespaces):
+            self._validate_decimal_places(
+                tax_total, "BR-DEC-13", "Invoice total VAT amount (BT-110)"
+            )
+
         # Validate VAT breakdown
         self._validate_vat_breakdown(settlement)
 
@@ -543,6 +684,10 @@ class EN16931Validator:
                         f"VAT breakdown {idx}: Taxable amount (BT-116) is mandatory",
                     )
                 )
+            else:
+                self._validate_decimal_places(
+                    basis, "BR-DEC-19", f"VAT breakdown {idx} taxable amount (BT-116)"
+                )
 
             # BR-AE-13: VAT category tax amount
             tax_amount = vat.find(".//ram:CalculatedAmount", self.namespaces)
@@ -552,6 +697,12 @@ class EN16931Validator:
                         "BR-AE-13",
                         f"VAT breakdown {idx}: Tax amount (BT-117) is mandatory",
                     )
+                )
+            else:
+                self._validate_decimal_places(
+                    tax_amount,
+                    "BR-DEC-20",
+                    f"VAT breakdown {idx} tax amount (BT-117)",
                 )
 
             # BR-AE-14: For standard rate, rate must be present
@@ -617,7 +768,7 @@ class EN16931Validator:
         currency_elem = settlement.find(".//ram:InvoiceCurrencyCode", self.namespaces)
         invoice_currency = currency_elem.text if currency_elem is not None else None
 
-        tax_total = 0.0
+        tax_total = Decimal(0)
         for tax_elem in tax_totals:
             currency_id = tax_elem.get("currencyID")
             if currency_id == invoice_currency or not currency_id:
@@ -641,7 +792,7 @@ class EN16931Validator:
         lines = transaction.findall(
             ".//ram:IncludedSupplyChainTradeLineItem", self.namespaces
         )
-        calculated_line_total = 0.0
+        calculated_line_total = Decimal(0)
         for line in lines:
             line_settlement = line.find(
                 ".//ram:SpecifiedLineTradeSettlement", self.namespaces
@@ -705,7 +856,7 @@ class EN16931Validator:
         trade_tax_totals = settlement.findall(
             ".//ram:ApplicableTradeTax", self.namespaces
         )
-        calculated_vat_total = 0.0
+        calculated_vat_total = Decimal(0)
         for tax in trade_tax_totals:
             calculated_vat_total += self._get_decimal(
                 tax.find(".//ram:CalculatedAmount", self.namespaces)
@@ -755,7 +906,7 @@ class EN16931Validator:
         lines = transaction.findall(
             ".//ram:IncludedSupplyChainTradeLineItem", self.namespaces
         )
-        category_line_total = 0.0
+        category_line_total = Decimal(0)
 
         for line in lines:
             line_tax = line.find(
@@ -858,21 +1009,33 @@ class EN16931Validator:
             ".//ram:SpecifiedTradeAllowanceCharge", self.namespaces
         )
 
-        total_allowances = 0.0
-        total_charges = 0.0
+        total_allowances = Decimal(0)
+        total_charges = Decimal(0)
 
         for ac in all_line_ac:
             charge_indicator = ac.find(
                 ".//ram:ChargeIndicator/udt:Indicator", self.namespaces
             )
-            ac_amount = self._get_decimal(
-                ac.find(".//ram:ActualAmount", self.namespaces)
-            )
+            ac_amount_element = ac.find(".//ram:ActualAmount", self.namespaces)
+            basis_element = ac.find(".//ram:BasisAmount", self.namespaces)
+            ac_amount = self._get_decimal(ac_amount_element)
 
             if charge_indicator is not None and charge_indicator.text:
                 if charge_indicator.text.lower() == "false":
+                    self._validate_decimal_places(
+                        ac_amount_element, "BR-DEC-01", "Line allowance amount (BT-136)"
+                    )
+                    self._validate_decimal_places(
+                        basis_element, "BR-DEC-02", "Line allowance base (BT-137)"
+                    )
                     total_allowances += ac_amount
                 elif charge_indicator.text.lower() == "true":
+                    self._validate_decimal_places(
+                        ac_amount_element, "BR-DEC-05", "Line charge amount (BT-141)"
+                    )
+                    self._validate_decimal_places(
+                        basis_element, "BR-DEC-06", "Line charge base (BT-142)"
+                    )
                     total_charges += ac_amount
 
         # BR-CO-03: Invoice line net amount = (quantity × price) - line allowances + line charges
@@ -919,7 +1082,27 @@ class EN16931Validator:
             percentage = self._get_decimal(
                 ac.find(".//ram:CalculationPercent", self.namespaces)
             )
-            amount = self._get_decimal(ac.find(".//ram:ActualAmount", self.namespaces))
+            amount_element = ac.find(".//ram:ActualAmount", self.namespaces)
+            amount = self._get_decimal(amount_element)
+
+            if charge_indicator.text.lower() == "false":
+                self._validate_decimal_places(
+                    amount_element, "BR-DEC-24", "Document allowance amount (BT-92)"
+                )
+                self._validate_decimal_places(
+                    ac.find(".//ram:BasisAmount", self.namespaces),
+                    "BR-DEC-25",
+                    "Document allowance base (BT-93)",
+                )
+            elif charge_indicator.text.lower() == "true":
+                self._validate_decimal_places(
+                    amount_element, "BR-DEC-27", "Document charge amount (BT-99)"
+                )
+                self._validate_decimal_places(
+                    ac.find(".//ram:BasisAmount", self.namespaces),
+                    "BR-DEC-28",
+                    "Document charge base (BT-100)",
+                )
 
             if base_amount > 0 and percentage > 0:
                 calculated_amount = base_amount * (percentage / 100)

--- a/weblate_web/management/commands/recurring_payments.py
+++ b/weblate_web/management/commands/recurring_payments.py
@@ -37,6 +37,7 @@ from weblate_web.payments.utils import send_notification
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from datetime import datetime
+    from decimal import Decimal
 
 
 class Command(BaseCommand):
@@ -143,7 +144,7 @@ class Command(BaseCommand):
         *,
         recurring: str,
         end_date: datetime,
-        amount: int | None = None,
+        amount: Decimal | int | None = None,
         extra: dict[str, int],
     ) -> None:
         # Allow at most three failures of current payment method
@@ -164,7 +165,7 @@ class Command(BaseCommand):
             return
 
         # Create repeated payment
-        if payment.paid_invoice:
+        if payment.paid_invoice and "donation_service" not in extra:
             if subscription_id := extra.get("subscription"):
                 subscription = Subscription.objects.get(pk=subscription_id)
                 invoice = subscription.create_invoice(kind=InvoiceKind.DRAFT)

--- a/weblate_web/models.py
+++ b/weblate_web/models.py
@@ -50,6 +50,7 @@ from weblate_web.invoices.models import (
     Invoice,
     InvoiceCategory,
     round_decimal,
+    round_money,
 )
 from weblate_web.payments.models import Customer, CustomerFollowUp, Payment
 from weblate_web.payments.utils import send_notification
@@ -1026,11 +1027,14 @@ class Service(models.Model):  # ruff:ignore[too-many-public-methods]
             and subscription.expires >= timezone.now()
         )
 
-    def get_donation_amount(self) -> int:
+    def get_donation_amount(self) -> Decimal:
         subscription = self.donation_subscription
         if subscription is None or not subscription.payment:
-            return 0
-        return subscription.payment_obj.amount
+            return Decimal(0)
+        payment = subscription.payment_obj
+        if payment.amount_fixed and payment.requested_amount is not None:
+            return payment.requested_amount
+        return payment.amount
 
     def get_donation_payment_description(self) -> str:
         subscription = self.donation_subscription
@@ -1560,10 +1564,10 @@ class Subscription(models.Model):
                 return ""
         return self.package.get_repeat()
 
-    def get_renewal_amount(self) -> int:
+    def get_renewal_amount(self) -> Decimal:
         if self.service.is_donation:
             return self.service.get_donation_amount()
-        return self.package.price
+        return Decimal(self.package.price)
 
     def get_renewal_extra(self) -> dict[str, int]:
         if self.service.is_donation:
@@ -1717,12 +1721,16 @@ class Subscription(models.Model):
             unit_price=self.get_upgrade_unit_price(package, currency),
         )
 
-    def get_expected_payment_amount(self) -> int:
+    def get_expected_payment_amount(self) -> Decimal:
         if self.service.is_donation:
             return self.get_renewal_amount()
         if discount := self.service.customer.discount:
-            return self.package.price * (100 - discount.percents) // 100
-        return self.package.price
+            return round_money(
+                Decimal(self.package.price)
+                * Decimal(100 - discount.percents)
+                / Decimal(100)
+            )
+        return Decimal(self.package.price)
 
 
 class SubscriptionPastPayment(models.Model):

--- a/weblate_web/payments/admin.py
+++ b/weblate_web/payments/admin.py
@@ -72,6 +72,7 @@ class PaymentAdmin(admin.ModelAdmin):
     list_display = (
         "description",
         "amount",
+        "requested_amount",
         "customer",
         "state",
         "backend",

--- a/weblate_web/payments/backends.py
+++ b/weblate_web/payments/backends.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import datetime
 import re
 from dataclasses import dataclass
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from hashlib import sha256
 from typing import TYPE_CHECKING, Any, cast
 
@@ -342,6 +342,14 @@ class Backend:
         if self.payment.repeat and not self.recurring:
             raise InvalidState(self.payment.get_state_display())
 
+        if (
+            self.payment.amount_fixed
+            and not self.payment.draft_invoice_id
+            and not self.payment.paid_invoice_id
+        ):
+            self.payment.normalize_fixed_amount()
+            self.payment.save(update_fields=["amount", "requested_amount"])
+
         result = self.perform(request, back_url, complete_url)
 
         # Update payment state
@@ -384,7 +392,6 @@ class Backend:
         )
 
         generate = True
-
         if self.payment.paid_invoice:
             raise ValueError("Invoice already exists!")
         invoice_kind = InvoiceKind.PROFORMA if proforma else InvoiceKind.INVOICE
@@ -408,7 +415,10 @@ class Backend:
                 )
         else:
             category = InvoiceCategory.HOSTING
-            if self.payment.extra.get("category") == "donate":
+            if (
+                self.payment.extra.get("category") == "donate"
+                or "donation_service" in self.payment.extra
+            ):
                 category = InvoiceCategory.DONATE
             # Generate manually if no draft is present (hosted integration)
             invoice = Invoice.objects.create(
@@ -422,7 +432,9 @@ class Backend:
             )
             invoice.invoiceitem_set.create(
                 description=self.payment.description,
-                unit_price=round(Decimal(self.payment.amount_without_vat), 3),
+                unit_price=self.payment.amount_without_vat.quantize(
+                    Decimal("0.001"), rounding=ROUND_HALF_UP
+                ),
             )
         if proforma:
             self.payment.draft_invoice = invoice
@@ -960,7 +972,7 @@ class ThePay2Card(Backend):
             payload = {
                 "uid": str(self.payment.pk),
                 "value": {
-                    "amount": str(int(self.payment.vat_amount * 100)),
+                    "amount": str(self.payment.vat_amount_minor),
                     "currency": self.payment.get_currency_display(),
                 },
                 "notif_url": complete_url,
@@ -980,7 +992,7 @@ class ThePay2Card(Backend):
             "can_customer_change_method": False,
             "is_customer_notification_enabled": False,
             "payment_method_code": self.thepay_method_code,
-            "amount": int(self.payment.vat_amount * 100),
+            "amount": self.payment.vat_amount_minor,
             "currency_code": self.payment.get_currency_display(),
             "uid": str(self.payment.pk),
             "description_for_customer": self.payment.description,

--- a/weblate_web/payments/migrations/0004_payment_decimal_amount.py
+++ b/weblate_web/payments/migrations/0004_payment_decimal_amount.py
@@ -1,0 +1,166 @@
+#
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from __future__ import annotations
+
+from decimal import ROUND_FLOOR, ROUND_HALF_UP, Decimal
+
+from django.db import migrations, models
+
+PAYMENT_QUANTUM = Decimal("0.01")
+EU_COUNTRIES = {
+    "AT",
+    "BE",
+    "BG",
+    "CY",
+    "CZ",
+    "DE",
+    "DK",
+    "EE",
+    "ES",
+    "FI",
+    "FR",
+    "GR",
+    "HR",
+    "HU",
+    "IE",
+    "IT",
+    "LT",
+    "LU",
+    "LV",
+    "MT",
+    "NL",
+    "PL",
+    "PT",
+    "RO",
+    "SE",
+    "SI",
+    "SK",
+}
+
+
+def round_money(amount):
+    return Decimal(amount).quantize(PAYMENT_QUANTUM, rounding=ROUND_HALF_UP)
+
+
+def round_legacy(amount, max_decimals=3):
+    if amount % Decimal("0.01"):
+        return round(amount, max_decimals)
+    if not amount % Decimal(1):
+        return round(amount, 0)
+    if not amount % Decimal("0.1"):
+        return round(amount, 1)
+    return round(amount, 2)
+
+
+def get_gross(tax_basis, vat_rate):
+    vat = round_money(tax_basis * Decimal(vat_rate) / Decimal(100))
+    return tax_basis + vat
+
+
+def get_compliant_amount(requested_amount, vat_rate):
+    requested = round_money(requested_amount)
+    tax_basis = (requested * Decimal(100) / Decimal(100 + vat_rate)).quantize(
+        PAYMENT_QUANTUM, rounding=ROUND_FLOOR
+    )
+    while get_gross(tax_basis, vat_rate) > requested:
+        tax_basis -= PAYMENT_QUANTUM
+    while get_gross(tax_basis + PAYMENT_QUANTUM, vat_rate) <= requested:
+        tax_basis += PAYMENT_QUANTUM
+    return get_gross(tax_basis, vat_rate)
+
+
+def customer_needs_vat(customer):
+    country = str(customer.country or "").upper()
+    vat = str(customer.vat or "").upper()
+    vat_country = vat[:2]
+    return not country or vat_country == "CZ" or (country in EU_COUNTRIES and not vat)
+
+
+def get_invoice_total(invoice):
+    if invoice.kind != 0:
+        total = sum(
+            (item.unit_price * item.quantity for item in invoice.invoiceitem_set.all()),
+            start=Decimal(0),
+        )
+        positive = sum(
+            (
+                item.unit_price * item.quantity
+                for item in invoice.invoiceitem_set.all()
+                if item.unit_price > 0
+            ),
+            start=Decimal(0),
+        )
+        if invoice.discount_id:
+            total -= round(positive * invoice.discount.percents / Decimal(100), 0)
+        tax_basis = round_legacy(total)
+        vat = round_legacy(tax_basis * invoice.vat_rate / Decimal(100))
+        return round_legacy(tax_basis + vat, max_decimals=2)
+
+    positive = Decimal("0.00")
+    allowances = Decimal("0.00")
+    for item in invoice.invoiceitem_set.all():
+        total = round_money(item.unit_price * item.quantity)
+        if total >= 0:
+            positive += total
+        else:
+            allowances -= total
+    if invoice.discount_id:
+        allowances += round_money(positive * invoice.discount.percents / Decimal(100))
+    tax_basis = round_money(positive - allowances)
+    vat = round_money(tax_basis * invoice.vat_rate / Decimal(100))
+    return tax_basis + vat
+
+
+def populate_requested_amount(apps, _schema_editor):
+    Payment = apps.get_model("payments", "Payment")
+    payments = Payment.objects.filter(amount_fixed=True).select_related(
+        "customer", "draft_invoice__discount"
+    )
+    for payment in payments.iterator():
+        requested = round_money(payment.amount)
+        amount = requested
+        if payment.state == 1:
+            if payment.draft_invoice_id:
+                amount = requested = get_invoice_total(payment.draft_invoice)
+            elif payment.currency != 1 and customer_needs_vat(payment.customer):
+                amount = get_compliant_amount(requested, 21)
+        payment.amount = amount
+        payment.requested_amount = requested
+        payment.save(update_fields=("amount", "requested_amount"))
+
+
+class Migration(migrations.Migration):
+    dependencies = [("payments", "0003_rename_customer_users_owners")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="payment",
+            name="amount",
+            field=models.DecimalField(decimal_places=2, max_digits=12),
+        ),
+        migrations.AddField(
+            model_name="payment",
+            name="requested_amount",
+            field=models.DecimalField(
+                blank=True, decimal_places=2, max_digits=12, null=True
+            ),
+        ),
+        migrations.RunPython(populate_requested_amount, migrations.RunPython.noop),
+    ]

--- a/weblate_web/payments/models.py
+++ b/weblate_web/payments/models.py
@@ -23,7 +23,7 @@ import os.path
 import re
 import uuid
 from datetime import timedelta
-from decimal import Decimal
+from decimal import ROUND_FLOOR, ROUND_HALF_UP, Decimal
 from email.message import Message
 from typing import TYPE_CHECKING, cast
 
@@ -106,6 +106,42 @@ VAT_COUNTRY_CODE_ALIASES = {
 }
 VAT_RATE = 21
 DELETED_MAIL = re.compile(r"noreply\+[0-9]+@weblate.org")
+PAYMENT_QUANTUM = Decimal("0.01")
+
+
+def round_payment_amount(amount: Decimal | int) -> Decimal:
+    """Round a fiat payment amount to cents."""
+    return Decimal(amount).quantize(PAYMENT_QUANTUM, rounding=ROUND_HALF_UP)
+
+
+def calculate_vat_amount(tax_basis: Decimal, vat_rate: int) -> Decimal:
+    """Calculate VAT from a cent-denominated tax basis."""
+    return round_payment_amount(tax_basis * Decimal(vat_rate) / Decimal(100))
+
+
+def get_compliant_fixed_amount(
+    requested_amount: Decimal | int, vat_rate: int
+) -> tuple[Decimal, Decimal]:
+    """Return the greatest compliant tax basis and gross not above requested."""
+    requested = round_payment_amount(requested_amount)
+    if not requested or vat_rate <= 0:
+        return requested, requested
+    sign = Decimal(-1) if requested < 0 else Decimal(1)
+    requested = abs(requested)
+
+    rate = Decimal(100 + vat_rate)
+    tax_basis = (requested * Decimal(100) / rate).quantize(
+        PAYMENT_QUANTUM, rounding=ROUND_FLOOR
+    )
+
+    def get_gross(candidate: Decimal) -> Decimal:
+        return candidate + calculate_vat_amount(candidate, vat_rate)
+
+    while get_gross(tax_basis) > requested:
+        tax_basis -= PAYMENT_QUANTUM
+    while get_gross(tax_basis + PAYMENT_QUANTUM) <= requested:
+        tax_basis += PAYMENT_QUANTUM
+    return sign * tax_basis, sign * get_gross(tax_basis)
 
 
 class CustomerQuerySet(models.QuerySet["Customer", "Customer"]):
@@ -731,7 +767,10 @@ class Payment(models.Model):
     CURRENCY_GBP = 4
 
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    amount = models.IntegerField()
+    amount = models.DecimalField(decimal_places=2, max_digits=12)
+    requested_amount = models.DecimalField(
+        blank=True, decimal_places=2, max_digits=12, null=True
+    )
     currency = models.IntegerField(
         choices=(
             (CURRENCY_EUR, "EUR"),
@@ -797,8 +836,50 @@ class Payment(models.Model):
     def __str__(self) -> str:
         return f"payment:{self.pk}"
 
+    def save(  # type: ignore[override]
+        self,
+        *,
+        force_insert: bool = False,
+        force_update: bool = False,
+        using=None,
+        update_fields=None,
+    ) -> None:
+        if self._state.adding:
+            if self.currency != self.CURRENCY_BTC:
+                self.amount = round_payment_amount(self.amount)
+            if self.amount_fixed and self.requested_amount is None:
+                self.requested_amount = self.amount
+            if self.state == self.NEW:
+                self.normalize_fixed_amount()
+        super().save(
+            force_insert=force_insert,
+            force_update=force_update,
+            using=using,
+            update_fields=update_fields,
+        )
+
     def get_absolute_url(self):
         return reverse("payment", kwargs={"pk": self.pk})
+
+    def normalize_fixed_amount(self) -> None:
+        """Recalculate a new fixed payment from the originally requested amount."""
+        if (
+            not self.amount_fixed
+            or self.currency == self.CURRENCY_BTC
+            or self.draft_invoice_id
+            or self.paid_invoice_id
+        ):
+            return
+        requested = round_payment_amount(
+            self.amount if self.requested_amount is None else self.requested_amount
+        )
+        self.requested_amount = requested
+        if self.customer.needs_vat:
+            self.amount = get_compliant_fixed_amount(requested, self.customer.vat_rate)[
+                1
+            ]
+        else:
+            self.amount = requested
 
     def get_reject_reason(self) -> str:
         if self.details.get("failure_code") == self.VAT_VALIDATION_FAILURE:
@@ -835,22 +916,38 @@ class Payment(models.Model):
 
     def get_amount_display(self):
         if self.currency == self.CURRENCY_BTC:
-            return self.amount / 100000000
+            return self.amount / Decimal(100000000)
         return self.amount
+
+    @property
+    def amount_was_adjusted(self) -> bool:
+        return (
+            self.requested_amount is not None
+            and self.currency != self.CURRENCY_BTC
+            and round_payment_amount(self.requested_amount)
+            != round_payment_amount(self.amount)
+        )
 
     @property
     def vat_amount(self) -> Decimal:
-        amount = Decimal(self.amount)
+        amount = round_payment_amount(self.amount)
         if self.customer.needs_vat and not self.amount_fixed:
-            rate = 100 + self.customer.vat_rate
-            return rate * amount / 100
+            return amount + calculate_vat_amount(amount, self.customer.vat_rate)
         return amount
 
     @property
-    def amount_without_vat(self):
+    def vat_amount_minor(self) -> int:
+        """Charged fiat amount in minor currency units."""
+        return int(self.vat_amount * 100)
+
+    @property
+    def amount_without_vat(self) -> Decimal:
         if self.customer.needs_vat and self.amount_fixed:
-            return 100.0 * self.amount / (100 + self.customer.vat_rate)
-        return self.amount
+            tax_basis, _gross = get_compliant_fixed_amount(
+                self.amount, self.customer.vat_rate
+            )
+            return tax_basis
+        return round_payment_amount(self.amount)
 
     def get_payment_url(self) -> str:
         return get_site_url("payment", strip_language=False, pk=self.pk)
@@ -893,7 +990,7 @@ class Payment(models.Model):
     def repeat_payment(
         self,
         skip_previous: bool = False,
-        amount: int | None = None,
+        amount: Decimal | int | None = None,
         extra: dict[str, int] | None = None,
         **kwargs,
     ):
@@ -922,9 +1019,18 @@ class Payment(models.Model):
             # Create new payment object
             if extra is None:
                 extra = {**self.extra, **kwargs}
+            repeated_amount = self.amount if amount is None else Decimal(amount)
+            requested_amount = None
+            if self.amount_fixed:
+                requested_amount = (
+                    self.requested_amount if amount is None else repeated_amount
+                )
+                repeated_amount = requested_amount or repeated_amount
             return Payment.objects.create(
-                amount=self.amount if amount is None else amount,
+                amount=repeated_amount,
+                requested_amount=requested_amount,
                 backend=self.backend,
+                currency=self.currency,
                 description=self.description,
                 recurring="",
                 customer=self.customer,

--- a/weblate_web/payments/tests.py
+++ b/weblate_web/payments/tests.py
@@ -235,19 +235,23 @@ class ModelTest(SimpleTestCase):
         self.assertEqual(payment.vat_amount, Decimal(121))
         payment = Payment(customer=customer, amount=100, amount_fixed=True)
         self.assertEqual(payment.vat_amount, Decimal(100))
-        self.assertAlmostEqual(payment.amount_without_vat, 82.64, places=2)
+        self.assertAlmostEqual(payment.amount_without_vat, Decimal("82.64"), places=2)
 
         customer.vat = "IE6388047V"
         payment = Payment(customer=customer, amount=100)
         self.assertEqual(payment.vat_amount, Decimal(100))
         payment = Payment(customer=customer, amount=100, amount_fixed=True)
         self.assertEqual(payment.vat_amount, Decimal(100))
-        self.assertEqual(payment.amount_without_vat, 100)
+        self.assertEqual(payment.amount_without_vat, Decimal(100))
 
     def test_vat_calculation_rounding(self) -> None:
-        payment = Payment(customer=Customer(**CUSTOMER), amount=15)
+        customer = Customer(**CUSTOMER)
+        payment = Payment(customer=customer, amount=15)
         self.assertEqual(payment.vat_amount, Decimal("18.15"))
-        self.assertEqual(int(payment.vat_amount * 100), 1815)
+        self.assertEqual(payment.vat_amount_minor, 1815)
+        payment.amount = Decimal("0.50")
+        self.assertEqual(payment.vat_amount, Decimal("0.61"))
+        self.assertEqual(payment.vat_amount_minor, 61)
 
     def test_short_filename(self) -> None:
         customer = Customer()
@@ -296,6 +300,80 @@ class ModelObjectsTestCase(TestCase):
         customer2.owners.add(User.objects.create())
         customer.merge(customer2)
         self.assertEqual(1, customer.owners.count())
+
+    def test_fixed_payment_is_adjusted_to_compliant_gross(self) -> None:
+        customer = Customer.objects.create(**CUSTOMER)
+        payment = Payment.objects.create(
+            customer=customer,
+            amount=4,
+            amount_fixed=True,
+            description="Donation",
+        )
+
+        self.assertEqual(payment.requested_amount, Decimal("4.00"))
+        self.assertEqual(payment.amount, Decimal("3.99"))
+        self.assertEqual(payment.amount_without_vat, Decimal("3.30"))
+        self.assertEqual(payment.vat_amount, Decimal("3.99"))
+        self.assertTrue(payment.amount_was_adjusted)
+
+        compatible = Payment.objects.create(
+            customer=customer,
+            amount=121,
+            amount_fixed=True,
+            description="Compatible donation",
+        )
+        self.assertEqual(compatible.amount, Decimal("121.00"))
+        self.assertFalse(compatible.amount_was_adjusted)
+
+        refund = Payment.objects.create(
+            customer=customer,
+            amount=-121,
+            amount_fixed=True,
+            description="Refund",
+        )
+        self.assertEqual(refund.amount, Decimal("-121.00"))
+        self.assertEqual(refund.amount_without_vat, Decimal("-100.00"))
+
+    def test_fixed_payment_recalculation_uses_requested_amount(self) -> None:
+        customer = Customer.objects.create(**CUSTOMER)
+        payment = Payment.objects.create(
+            customer=customer,
+            amount=4,
+            amount_fixed=True,
+            description="Recurring donation",
+            backend="pay",
+            recurring="y",
+        )
+        self.assertEqual(payment.amount, Decimal("3.99"))
+
+        customer.country = "US"
+        customer.vat = ""
+        customer.save(update_fields=["country", "vat"])
+        payment.normalize_fixed_amount()
+        payment.save(update_fields=["amount", "requested_amount"])
+        self.assertEqual(payment.amount, Decimal("4.00"))
+
+        customer.country = "CZ"
+        customer.save(update_fields=["country"])
+        repeated = payment.repeat_payment(skip_previous=True)
+        self.assertIsInstance(repeated, Payment)
+        if not isinstance(repeated, Payment):
+            self.fail("Recurring payment was not created")
+        self.assertEqual(repeated.requested_amount, Decimal("4.00"))
+        self.assertEqual(repeated.amount, Decimal("3.99"))
+
+    def test_btc_amount_keeps_satoshi_representation(self) -> None:
+        customer = Customer.objects.create(**CUSTOMER)
+        payment = Payment.objects.create(
+            customer=customer,
+            amount=100_000_000,
+            amount_fixed=True,
+            currency=Payment.CURRENCY_BTC,
+            description="Historical Bitcoin payment",
+        )
+
+        self.assertEqual(payment.amount, Decimal(100000000))
+        self.assertEqual(payment.get_amount_display(), Decimal(1))
 
     def test_automated_vies_transient_fault_is_not_logged(self) -> None:
         for code in (
@@ -409,7 +487,7 @@ class BackendTest(BackendBaseTestCase):
         invoice: Invoice,
         payment_message: str = "",
         *,
-        amount: int | None = None,
+        amount: Decimal | int | None = None,
         currency: str = "EUR",
         sender_account: str | None = None,
         transaction_id: int | None = 12210832097,
@@ -422,8 +500,8 @@ class BackendTest(BackendBaseTestCase):
             payment_message = invoice.number
         transaction[0]["column16"]["value"] = payment_message
         transaction[1]["column16"]["value"] = payment_message
-        transaction[1]["column1"]["value"] = (
-            int(invoice.total_amount) if amount is None else amount
+        transaction[1]["column1"]["value"] = float(
+            invoice.total_amount if amount is None else amount
         )
         if sender_account is not None:
             transaction[1]["column2"] = {
@@ -468,6 +546,48 @@ class BackendTest(BackendBaseTestCase):
         self.assertEqual(mail.outbox[0].subject, "Your payment on weblate.org")
         self.assertIn("You are the heart of Weblate", mail.outbox[0].body)
         self.assertNotIn("Thank you for your payment", mail.outbox[0].body)
+
+    def test_fixed_donation_generates_compliant_invoice(self) -> None:
+        payment = Payment.objects.create(
+            customer=self.customer,
+            amount=4,
+            amount_fixed=True,
+            description="Fixed donation",
+            backend="pay",
+            extra={"category": "donate"},
+        )
+        backend = get_backend("pay")(payment)
+
+        self.assertEqual(payment.requested_amount, Decimal("4.00"))
+        self.assertEqual(payment.amount, Decimal("3.99"))
+        self.assertTrue(backend.success())
+
+        payment.refresh_from_db()
+        invoice = cast("Invoice", payment.paid_invoice)
+        self.assertEqual(invoice.total_amount_no_vat, Decimal("3.30"))
+        self.assertEqual(invoice.total_vat, Decimal("0.69"))
+        self.assertEqual(invoice.total_amount, Decimal("3.99"))
+
+    def test_linked_fixed_payment_is_not_renormalized(self) -> None:
+        self.customer.country = "US"
+        self.customer.vat = ""
+        self.customer.save(update_fields=["country", "vat"])
+        invoice = Invoice.objects.create(
+            customer=self.customer,
+            kind=InvoiceKind.INVOICE,
+            category=InvoiceCategory.HOSTING,
+        )
+        invoice.invoiceitem_set.create(description="Fixed invoice", unit_price=4)
+
+        self.customer.country = "CZ"
+        self.customer.save(update_fields=["country"])
+        payment = invoice.create_payment(backend="pay")
+        self.assertEqual(payment.amount, Decimal("4.00"))
+        backend = get_backend("pay")(payment)
+        self.assertIsNone(backend.initiate(None, "", ""))
+
+        payment.refresh_from_db()
+        self.assertEqual(payment.amount, Decimal("4.00"))
 
     def test_reject(self) -> None:
         backend = get_backend("reject")(self.payment)
@@ -538,7 +658,7 @@ class BackendTest(BackendBaseTestCase):
         transaction = received["accountStatement"]["transactionList"]["transaction"]  # type: ignore[index]
         transaction[0]["column16"]["value"] = proforma_id
         transaction[1]["column16"]["value"] = proforma_id
-        transaction[1]["column1"]["value"] = backend.payment.amount * 1.21
+        transaction[1]["column1"]["value"] = float(backend.payment.vat_amount)
         responses.replace(responses.GET, FIO_API, body=json.dumps(received))
         FioBank.fetch_payments()
         payment = self.check_payment(Payment.ACCEPTED)
@@ -583,7 +703,7 @@ class BackendTest(BackendBaseTestCase):
         payment_message = format_string.format(invoice.number)
         transaction[0]["column16"]["value"] = payment_message
         transaction[1]["column16"]["value"] = payment_message
-        transaction[1]["column1"]["value"] = int(invoice.total_amount)
+        transaction[1]["column1"]["value"] = float(invoice.total_amount)
         responses.replace(responses.GET, FIO_API, body=json.dumps(received))
         FioBank.fetch_payments()
         self.assertTrue(invoice.paid_payment_set.exists())
@@ -608,6 +728,31 @@ class BackendTest(BackendBaseTestCase):
     def test_invoice_vs(self) -> None:
         # Czech bank notation
         self.test_invoice_bank(format_string="VS{}/SS/KS")
+
+    @responses.activate
+    @override_settings(
+        FIO_TOKEN="test-token",  # ruff:ignore[hardcoded-password-func-arg]
+    )
+    def test_invoice_bank_matches_cent_amount(self) -> None:
+        mock_vies()
+        cnb_mock_rates()
+        invoice = Invoice.objects.create(
+            customer=self.customer,
+            kind=InvoiceKind.INVOICE,
+            category=InvoiceCategory.HOSTING,
+            vat_rate=21,
+        )
+        invoice.invoiceitem_set.create(
+            description="Cent-bearing item", unit_price=Decimal("50.00")
+        )
+        invoice.generate_files()
+
+        self.mock_fio_payment(invoice)
+        FioBank.fetch_payments()
+
+        payment = invoice.paid_payment_set.get()
+        self.assertEqual(payment.amount, Decimal("60.50"))
+        self.assertEqual(invoice.total_amount, Decimal("60.50"))
 
     @responses.activate
     @override_settings(
@@ -1052,6 +1197,50 @@ class ThePay2Test(BackendBaseTestCase):
         self.check_payment(Payment.ACCEPTED)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "Your payment on weblate.org")
+
+    @responses.activate
+    def test_cent_amount_is_sent_as_minor_units(self) -> None:
+        self.payment.amount = Decimal("0.50")
+        self.payment.save(update_fields=["amount"])
+        backend = self.payment.get_payment_backend()
+        thepay_mock_create_payment()
+
+        backend.initiate(None, "", "")
+
+        payload = json.loads(cast("bytes", responses.calls[0].request.body))
+        self.assertEqual(payload["amount"], 61)
+
+    @responses.activate
+    def test_fixed_amount_is_renormalized_before_initiation(self) -> None:
+        self.customer.country = "US"
+        self.customer.vat = ""
+        self.customer.save(update_fields=["country", "vat"])
+        payment = Payment.objects.create(
+            customer=self.customer,
+            amount=4,
+            amount_fixed=True,
+            description="Fixed donation",
+            backend="thepay2-card",
+            extra={"category": "donate"},
+        )
+        self.assertEqual(payment.amount, Decimal("4.00"))
+
+        self.customer.country = "CZ"
+        self.customer.save(update_fields=["country"])
+        backend = payment.get_payment_backend()
+        thepay_mock_create_payment()
+        cnb_mock_rates()
+
+        backend.initiate(None, "", "")
+
+        payload = json.loads(cast("bytes", responses.calls[0].request.body))
+        self.assertEqual(payload["amount"], 399)
+        self.assertEqual(backend.payment.amount, Decimal("3.99"))
+        self.assertTrue(backend.success())
+        invoice = cast("Invoice", backend.payment.paid_invoice)
+        self.assertEqual(invoice.total_amount_no_vat, Decimal("3.30"))
+        self.assertEqual(invoice.total_vat, Decimal("0.69"))
+        self.assertEqual(invoice.total_amount, Decimal("3.99"))
 
     @responses.activate
     def test_unpaid(self) -> None:

--- a/weblate_web/templates/payment/payment.html
+++ b/weblate_web/templates/payment/payment.html
@@ -24,6 +24,17 @@
               </div>
               <div class="clear"></div>
             </div>
+            {% if object.amount_was_adjusted %}
+              <div class="form-line">
+                <div class="line-left">{% translate "Donation adjustment" %}</div>
+                <div class="line-right">
+                  <span class="text-muted">
+                    {% blocktranslate with requested=object.requested_amount|price_format:object.get_currency_display charged=object.vat_amount|price_format:object.get_currency_display %}The requested donation of {{ requested }} was adjusted down to {{ charged }} so that VAT can be calculated correctly.{% endblocktranslate %}
+                  </span>
+                </div>
+                <div class="clear"></div>
+              </div>
+            {% endif %}
             <div class="form-line">
               <div class="line-left">{% translate "Payment description" %}</div>
               <div class="line-right" lang="en" dir="ltr">{{ object.description }}</div>

--- a/weblate_web/tests.py
+++ b/weblate_web/tests.py
@@ -1290,6 +1290,38 @@ class PaymentCustomerAccessTest(UserTestCase):
         self.assertEqual(payment.amount, 100)
         self.assertTrue(payment.amount_fixed)
 
+    def test_customer_edit_recalculates_fixed_donation_from_request(self) -> None:
+        owner = self.login()
+        customer = self.create_customer(owner)
+        customer.country = "US"
+        customer.save(update_fields=["country"])
+        payment, payment_url, customer_url = self.create_payment(owner, customer)
+        payment.amount = Decimal("4.00")
+        payment.requested_amount = Decimal("4.00")
+        payment.amount_fixed = True
+        payment.extra = {"category": "donate", "reward": 1}
+        payment.save(
+            update_fields=["amount", "requested_amount", "amount_fixed", "extra"]
+        )
+        self.assertEqual(payment.amount, Decimal("4.00"))
+
+        response = self.client.post(customer_url, self.edit_data, follow=True)
+
+        self.assertRedirects(response, payment_url)
+        self.assertContains(response, "requested donation of €4")
+        self.assertContains(response, "adjusted down to €3.99")
+        payment.refresh_from_db()
+        self.assertEqual(payment.requested_amount, Decimal("4.00"))
+        self.assertEqual(payment.amount, Decimal("3.99"))
+
+        response = self.client.post(
+            customer_url, {**self.edit_data, "country": "US"}, follow=True
+        )
+        self.assertNotContains(response, "Donation adjustment")
+        payment.refresh_from_db()
+        self.assertEqual(payment.requested_amount, Decimal("4.00"))
+        self.assertEqual(payment.amount, Decimal("4.00"))
+
     def test_customer_edit_does_not_update_linked_proforma(self) -> None:
         owner = self.login()
         customer = self.create_customer(owner)
@@ -2246,14 +2278,14 @@ class PaymentTest(FakturaceTestCase):
         self.assertContains(response, "Please provide your billing")
         payment = Payment.objects.all().get()
         self.assertEqual(payment.state, Payment.NEW)
-        self.assertEqual(payment.amount, 50)
+        self.assertEqual(payment.amount, Decimal("50.82"))
         self.assertEqual(cast("Invoice", payment.draft_invoice).vat_rate, 21)
         customer_url = reverse("payment-customer", kwargs={"pk": payment.uuid})
         payment_url = reverse("payment", kwargs={"pk": payment.uuid})
         self.assertRedirects(response, customer_url)
         response = self.client.post(customer_url, TEST_CUSTOMER, follow=True)
         self.assertContains(response, "Please choose payment method")
-        self.assertContains(response, "€50")
+        self.assertContains(response, "€50.82")
         self.assertContains(response, "(including VAT)")
         response = self.client.post(payment_url, {"method": "thepay2-card"})
         self.assertEqual(response.status_code, 302)
@@ -4375,11 +4407,22 @@ class ExpiryTest(FakturaceTestCase):
         self.assertFalse(subscription.enabled)
 
     def test_expiring_recurring_donate(self) -> None:
-        self.create_donation(years=0, days=-2)
+        donation = self.create_donation(years=0, days=-2)
+        subscription = cast("Subscription", donation.donation_subscription)
+        payment = subscription.payment_obj
+        payment.paid_invoice = Invoice.objects.create(
+            kind=InvoiceKind.INVOICE,
+            category=InvoiceCategory.DONATE,
+            customer=payment.customer,
+        )
+        payment.save(update_fields=["paid_invoice"])
         RecurringPaymentsCommand.notify_expiry(force_summary=True)
         self.assert_notifications()
         RecurringPaymentsCommand.handle_donations()
         self.assert_notifications("Your payment on weblate.org")
+        repeated = Payment.objects.get(repeat=payment)
+        repeated_invoice = cast("Invoice", repeated.paid_invoice)
+        self.assertEqual(repeated_invoice.category, InvoiceCategory.DONATE)
         RecurringPaymentsCommand.handle_donations()
         self.assert_notifications()
 
@@ -4819,7 +4862,13 @@ class ServiceTest(FakturaceTestCase):
 
         discount.percents = 10
         discount.save()
-        self.assertEqual(subscription.get_expected_payment_amount(), 37)
+        self.assertEqual(subscription.get_expected_payment_amount(), Decimal("37.80"))
+
+        subscription.package.price = 1027
+        subscription.package.save(update_fields=["price"])
+        discount.percents = 50
+        discount.save(update_fields=["percents"])
+        self.assertEqual(subscription.get_expected_payment_amount(), Decimal("513.50"))
 
     def test_recurring_donation_payment_uses_previous_amount_and_donation_extra(
         self,
@@ -4828,7 +4877,11 @@ class ServiceTest(FakturaceTestCase):
         subscription = cast("Subscription", donation.donation_subscription)
         self.assertIsNotNone(subscription.payment)
         payment = cast("Payment", subscription.payment)
-        Payment.objects.filter(pk=payment.pk).update(amount=123)
+        Payment.objects.filter(pk=payment.pk).update(
+            amount=Decimal("122.99"),
+            amount_fixed=True,
+            requested_amount=Decimal("123.00"),
+        )
 
         with patch.object(
             RecurringPaymentsCommand, "peform_payment"
@@ -4839,7 +4892,7 @@ class ServiceTest(FakturaceTestCase):
         self.assertEqual(
             perform_payment.call_args.kwargs,
             {
-                "amount": 123,
+                "amount": Decimal("123.00"),
                 "recurring": "y",
                 "end_date": subscription.expires,
                 "extra": {"donation_service": donation.pk},
@@ -4938,7 +4991,7 @@ class ServiceTest(FakturaceTestCase):
         self.assertEqual(len(hosted), 1)
         self.assertEqual(hosted[0].package.name, "test:test-1-m")
         payment = hosted[0].payment_obj
-        self.assertEqual(payment.amount, 50)
+        self.assertEqual(payment.amount, Decimal("50.82"))
         self.assertEqual(
             hosted[0].expires.date(),
             timezone.now().date() + timedelta(days=3) + relativedelta(months=1),
@@ -4969,7 +5022,7 @@ class ServiceTest(FakturaceTestCase):
         hosted = service.hosted_subscriptions
         self.assertEqual(len(hosted), 1)
         self.assertEqual(hosted[0].package.name, "test:test-1")
-        self.assertEqual(hosted[0].payment_obj.amount, 508)
+        self.assertEqual(hosted[0].payment_obj.amount, Decimal("508.20"))
         self.assertEqual(
             hosted[0].expires.date(),
             timezone.now().date() + timedelta(days=3) + relativedelta(years=1),

--- a/weblate_web/tests_e2e/test_invoice_screenshots.py
+++ b/weblate_web/tests_e2e/test_invoice_screenshots.py
@@ -300,6 +300,7 @@ def test_invoice_pdf_screenshots(settings, tmp_path):
             slug="quote-support",
             kind=InvoiceKind.QUOTE,
             country="FR",
+            vat="FR40303265045",
             customer_reference="RFQ-26-42",
             items=(
                 InvoiceItemData(

--- a/weblate_web/views.py
+++ b/weblate_web/views.py
@@ -610,8 +610,12 @@ class CustomerView(FormView, PaymentObjectMixin):
             if invoice.kind == InvoiceKind.DRAFT:
                 invoice.vat_rate = customer.vat_rate
                 invoice.save(update_fields=["vat_rate"])
-                self.object.amount = int(invoice.total_amount)
-                self.object.save(update_fields=["amount"])
+                self.object.amount = invoice.total_amount
+                self.object.requested_amount = invoice.total_amount
+                self.object.save(update_fields=["amount", "requested_amount"])
+        elif self.object.amount_fixed:
+            self.object.normalize_fixed_amount()
+            self.object.save(update_fields=["amount", "requested_amount"])
         return redirect("payment", pk=self.object.pk)
 
     def get_form_kwargs(self):


### PR DESCRIPTION
Store fiat payments with cent precision and normalize fixed gross donations before charging so VAT can be calculated bottom-up. Keep issued invoice totals independent of linked payments to avoid truncated receipts and invalid VAT breakdowns.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
