### PR TITLE
fix(invoices): derive VAT rate from customer status

### DIFF
--- a/weblate_web/invoices/models.py
+++ b/weblate_web/invoices/models.py
@@ -478,6 +478,8 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
         if self.extra is None:
             self.extra = {}
         extra_fields: list[str] = []
+        if self._derive_initial_vat_rate():
+            extra_fields.append("vat_rate")
         if not self.tax_date:
             self.tax_date = self.issue_date
             extra_fields.append("tax_date")
@@ -515,12 +517,36 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
 
     def clean(self) -> None:
         super().clean()
+        self._derive_initial_vat_rate()
         if self.customer_id and self.kind in {
             InvoiceKind.INVOICE,
             InvoiceKind.PROFORMA,
             InvoiceKind.QUOTE,
         }:
             self._get_en_16931_tax_details()
+
+    def _derive_initial_vat_rate(self) -> bool:
+        if not self._state.adding or self.parent_id or not self.customer_id:
+            return False
+        if (
+            self.customer.is_eu
+            and self.customer.country_code != "CZ"
+            and self.customer.vat
+            and not self.customer.has_valid_vat
+        ):
+            raise ValidationError(
+                {
+                    "vat_rate": gettext(
+                        "EU reverse-charge invoices require a valid buyer VAT ID."
+                    )
+                }
+            )
+        if not self.vat_rate:
+            vat_rate = self.customer.vat_rate
+            if vat_rate != self.vat_rate:
+                self.vat_rate = vat_rate
+                return True
+        return False
 
     def is_editable(self) -> bool:
         if self.kind == InvoiceKind.INVOICE:
@@ -985,11 +1011,11 @@ class Invoice(models.Model):  # ruff:ignore[too-many-public-methods]
                 {"vat_rate": gettext("Czech invoices cannot use a zero VAT rate.")}
             )
         if self.customer.is_eu:
-            if not self.customer.vat:
+            if not self.customer.has_valid_vat:
                 raise ValidationError(
                     {
                         "vat_rate": gettext(
-                            "EU reverse-charge invoices require a buyer VAT ID."
+                            "EU reverse-charge invoices require a valid buyer VAT ID."
                         )
                     }
                 )

--- a/weblate_web/invoices/tests.py
+++ b/weblate_web/invoices/tests.py
@@ -53,7 +53,7 @@ class InvoiceTestCase(UserTestCase):  # ruff:ignore[too-many-public-methods]
         accounting_reference: str = "",
         country: str = "DE",
     ) -> Customer:
-        return Customer.objects.create(
+        customer = Customer.objects.create(
             name="Zkušební zákazník",
             address="Street 42",
             city="City",
@@ -65,6 +65,10 @@ class InvoiceTestCase(UserTestCase):  # ruff:ignore[too-many-public-methods]
             email=email,
             accounting_reference=accounting_reference,
         )
+        if vat:
+            customer.vat_validation_state = Customer.VatValidationState.VALID
+            customer.save(update_fields=["vat_validation_state"])
+        return customer
 
     def create_invoice_base(  # ruff:ignore[too-many-arguments]
         self,
@@ -228,6 +232,106 @@ class InvoiceTestCase(UserTestCase):  # ruff:ignore[too-many-public-methods]
         invoice.get_money_s3_xml_tree(invoices)
         return document
 
+    def test_initial_vat_rate_is_derived_from_customer(self) -> None:
+        cases = (
+            ("Czech customer", "CZ", "", Customer.VatValidationState.UNKNOWN, 21),
+            ("EU end user", "DE", "", Customer.VatValidationState.UNKNOWN, 21),
+            (
+                "EU customer with valid VAT",
+                "DE",
+                "DE123456789",
+                Customer.VatValidationState.VALID,
+                0,
+            ),
+            ("non-EU customer", "US", "", Customer.VatValidationState.UNKNOWN, 0),
+        )
+
+        for name, country, vat, validation_state, expected_rate in cases:
+            with self.subTest(name):
+                customer = self.create_customer(country=country, vat=vat)
+                customer.vat_validation_state = validation_state
+                customer.save(update_fields=["vat_validation_state"])
+
+                invoice = Invoice.objects.create(
+                    customer=customer,
+                    kind=InvoiceKind.DRAFT,
+                    category=InvoiceCategory.HOSTING,
+                )
+
+                self.assertEqual(invoice.vat_rate, expected_rate)
+
+    def test_initial_vat_rate_rejects_unvalidated_eu_vat(self) -> None:
+        for validation_state in (
+            Customer.VatValidationState.UNKNOWN,
+            Customer.VatValidationState.INVALID,
+        ):
+            with self.subTest(validation_state=validation_state):
+                customer = self.create_customer(country="DE", vat="DE123456789")
+                customer.vat_validation_state = validation_state
+                customer.save(update_fields=["vat_validation_state"])
+
+                with self.assertRaisesMessage(
+                    ValidationError,
+                    "EU reverse-charge invoices require a valid buyer VAT ID.",
+                ):
+                    Invoice.objects.create(
+                        customer=customer,
+                        kind=InvoiceKind.DRAFT,
+                        category=InvoiceCategory.HOSTING,
+                    )
+
+    def test_initial_positive_vat_rate_is_preserved(self) -> None:
+        invoice = Invoice.objects.create(
+            customer=self.create_customer(country="DE"),
+            kind=InvoiceKind.DRAFT,
+            category=InvoiceCategory.HOSTING,
+            vat_rate=19,
+        )
+
+        self.assertEqual(invoice.vat_rate, 19)
+
+        invoice.vat_rate = 7
+        invoice.save(update_fields=["vat_rate"])
+        invoice.refresh_from_db()
+        self.assertEqual(invoice.vat_rate, 7)
+
+    def test_invoice_form_rejects_unvalidated_eu_vat(self) -> None:
+        customer = self.create_customer(country="DE", vat="DE123456789")
+        customer.vat_validation_state = Customer.VatValidationState.INVALID
+        customer.save(update_fields=["vat_validation_state"])
+        invoice_form = modelform_factory(
+            Invoice,
+            fields=("kind", "category", "customer", "vat_rate", "currency"),
+        )
+        form = invoice_form(
+            data={
+                "kind": InvoiceKind.INVOICE,
+                "category": InvoiceCategory.HOSTING,
+                "customer": customer.pk,
+                "vat_rate": 0,
+                "currency": Currency.EUR,
+            }
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertFormError(
+            form,
+            "vat_rate",
+            "EU reverse-charge invoices require a valid buyer VAT ID.",
+        )
+
+    def test_duplicate_preserves_explicit_zero_vat_rate(self) -> None:
+        invoice = self.create_invoice(
+            country="DE", vat="DE123456789", kind=InvoiceKind.DRAFT
+        )
+        invoice.customer.vat_validation_state = Customer.VatValidationState.UNKNOWN
+        invoice.customer.save(update_fields=["vat_validation_state"])
+
+        duplicate = invoice.duplicate(kind=InvoiceKind.DRAFT)
+
+        self.assertEqual(duplicate.vat_rate, 0)
+        self.assertEqual(duplicate.total_amount, invoice.total_amount)
+
     def test_accounting_export_tax_classifications(self) -> None:
         cases = (
             (
@@ -349,19 +453,24 @@ class InvoiceTestCase(UserTestCase):  # ruff:ignore[too-many-public-methods]
 
     def test_invalid_zero_vat_states_are_rejected_before_generation(self) -> None:
         cases = (
-            ("CZ", "CZ21668027"),
-            ("DE", ""),
+            ("CZ", "CZ21668027", Customer.VatValidationState.VALID),
+            ("DE", "", Customer.VatValidationState.UNKNOWN),
+            ("DE", "DE123456789", Customer.VatValidationState.UNKNOWN),
+            ("DE", "DE123456789", Customer.VatValidationState.INVALID),
         )
-        for country, vat in cases:
+        for country, vat, validation_state in cases:
             with (
-                self.subTest(country=country),
+                self.subTest(
+                    country=country, vat=vat, validation_state=validation_state
+                ),
                 TemporaryDirectory() as temp_dir,
                 override_settings(INVOICES_PATH=Path(temp_dir)),
             ):
                 invoice = self.create_invoice(country=country, vat=vat)
-                if not vat:
-                    invoice.customer.vat = ""
-                    invoice.customer.save(update_fields=["vat"])
+                invoice.customer.vat_validation_state = validation_state
+                invoice.customer.save(update_fields=["vat_validation_state"])
+                invoice.vat_rate = 0
+                invoice.save(update_fields=["vat_rate"])
 
                 with self.assertRaises(ValidationError):
                     invoice.full_clean()
@@ -376,6 +485,8 @@ class InvoiceTestCase(UserTestCase):  # ruff:ignore[too-many-public-methods]
         invoice = self.create_invoice(
             country="CZ", vat="CZ21668027", kind=InvoiceKind.DRAFT
         )
+        invoice.vat_rate = 0
+        invoice.save(update_fields=["vat_rate"])
 
         invoice.full_clean()
         with self.assertRaises(ValidationError):
@@ -383,6 +494,8 @@ class InvoiceTestCase(UserTestCase):  # ruff:ignore[too-many-public-methods]
 
     def test_quote_validation_rejects_incomplete_tax_state(self) -> None:
         invoice = self.create_invoice(country="FR", kind=InvoiceKind.QUOTE)
+        invoice.vat_rate = 0
+        invoice.save(update_fields=["vat_rate"])
 
         with self.assertRaises(ValidationError):
             invoice.full_clean()
@@ -668,7 +781,7 @@ class InvoiceTestCase(UserTestCase):  # ruff:ignore[too-many-public-methods]
     @responses.activate
     def test_total(self) -> None:
         self.mock_requests()
-        invoice = self.create_invoice(vat="CZ8003280318")
+        invoice = self.create_invoice(vat="DE123456789")
         self.assertEqual(invoice.total_amount, 100)
         self.validate_invoice(invoice)
 

--- a/weblate_web/management/commands/recurring_payments.py
+++ b/weblate_web/management/commands/recurring_payments.py
@@ -164,6 +164,35 @@ class Command(BaseCommand):
             payment.save()
             return
 
+        if payment.customer.vat:
+            validation_failed = False
+            validation_detail = ""
+            try:
+                payment.customer.prepayment_validation(automated=True)
+            except ValidationError as error:
+                validation_failed = True
+                validation_detail = strip_tags(str(error.message))
+            if payment.customer.vat_recently_invalid:
+                validation_failed = True
+                validation_detail = strip_tags(
+                    payment.customer.vat_validation_error["message"]
+                )
+            if validation_failed:
+                repeated = payment.repeat_payment(
+                    skip_previous=True, amount=amount, extra=extra
+                )
+                if not repeated:
+                    payment.recurring = ""
+                    payment.save()
+                    return
+                repeated.state = Payment.REJECTED
+                repeated.details["failure_code"] = Payment.VAT_VALIDATION_FAILURE
+                if validation_detail:
+                    repeated.details["failure_detail"] = validation_detail
+                repeated.save(update_fields=["state", "details"])
+                repeated.customer.send_notification("payment_failed", payment=repeated)
+                return
+
         # Create repeated payment
         if payment.paid_invoice and "donation_service" not in extra:
             if subscription_id := extra.get("subscription"):
@@ -188,28 +217,6 @@ class Command(BaseCommand):
             payment.recurring = ""
             payment.save()
             return
-
-        if repeated.customer.vat:
-            validation_failed = False
-            validation_detail = ""
-            try:
-                repeated.customer.prepayment_validation(automated=True)
-            except ValidationError as error:
-                validation_failed = True
-                validation_detail = strip_tags(str(error.message))
-            if repeated.customer.vat_recently_invalid:
-                validation_failed = True
-                validation_detail = strip_tags(
-                    repeated.customer.vat_validation_error["message"]
-                )
-            if validation_failed:
-                repeated.state = Payment.REJECTED
-                repeated.details["failure_code"] = Payment.VAT_VALIDATION_FAILURE
-                if validation_detail:
-                    repeated.details["failure_detail"] = validation_detail
-                repeated.save(update_fields=["state", "details"])
-                repeated.customer.send_notification("payment_failed", payment=repeated)
-                return
 
         # Trigger of the payment
         repeated.trigger_recurring()

--- a/weblate_web/payments/models.py
+++ b/weblate_web/payments/models.py
@@ -482,9 +482,17 @@ class Customer(models.Model):
         return self.is_eu and not self.vat
 
     @property
+    def has_valid_vat(self) -> bool:
+        return bool(
+            self.vat and self.vat_validation_state == self.VatValidationState.VALID
+        )
+
+    @property
     def needs_vat(self) -> bool:
         return (
-            not self.country_code or self.vat_country_code == "CZ" or self.is_eu_enduser
+            not self.country_code
+            or self.vat_country_code == "CZ"
+            or (self.is_eu and not self.has_valid_vat)
         )
 
     @property

--- a/weblate_web/payments/tests.py
+++ b/weblate_web/payments/tests.py
@@ -188,6 +188,15 @@ class ModelTest(SimpleTestCase):
         self.assertEqual(customer.vat_rate, 21)
         # EU company does not need VAT
         customer.vat = "IE6388047V"
+        self.assertFalse(customer.has_valid_vat)
+        self.assertTrue(customer.needs_vat)
+        self.assertEqual(customer.vat_rate, 21)
+        customer.vat_validation_state = Customer.VatValidationState.INVALID
+        self.assertFalse(customer.has_valid_vat)
+        self.assertTrue(customer.needs_vat)
+        self.assertEqual(customer.vat_rate, 21)
+        customer.vat_validation_state = Customer.VatValidationState.VALID
+        self.assertTrue(customer.has_valid_vat)
         self.assertFalse(customer.needs_vat)
         self.assertEqual(customer.vat_rate, 0)
         # Non EU customer does not need VAT
@@ -238,6 +247,7 @@ class ModelTest(SimpleTestCase):
         self.assertAlmostEqual(payment.amount_without_vat, Decimal("82.64"), places=2)
 
         customer.vat = "IE6388047V"
+        customer.vat_validation_state = Customer.VatValidationState.VALID
         payment = Payment(customer=customer, amount=100)
         self.assertEqual(payment.vat_amount, Decimal(100))
         payment = Payment(customer=customer, amount=100, amount_fixed=True)

--- a/weblate_web/tests.py
+++ b/weblate_web/tests.py
@@ -4687,7 +4687,11 @@ class ServiceTest(FakturaceTestCase):
         service = self.create_service(years=0, days=-2)
         subscription = service.subscription_set.get()
         expires = subscription.expires
-        self.set_customer_vat(service)
+        self.set_customer_vat(
+            service,
+            state=Customer.VatValidationState.UNKNOWN,
+            validated=timezone.now() - timedelta(days=VAT_VALIDITY_DAYS),
+        )
 
         with patch("weblate_web.payments.models.validate_vatin") as validate:
             RecurringPaymentsCommand.handle_subscriptions()
@@ -4695,8 +4699,36 @@ class ServiceTest(FakturaceTestCase):
         validate.assert_called_once()
         repeated = subscription.payment_obj.payment_set.get()
         self.assertEqual(repeated.state, Payment.PROCESSED)
+        self.assertEqual(repeated.amount, subscription.get_renewal_amount())
         subscription.refresh_from_db()
         self.assertGreater(subscription.expires, expires)
+
+    def test_recurring_invoice_validates_vat_before_pricing(self) -> None:
+        service = self.create_service(years=0, days=-2)
+        Customer.objects.filter(pk=service.customer_id).update(
+            country="DE",
+            vat="DE123456789",
+            vat_validated=timezone.now(),
+            vat_validation_state=Customer.VatValidationState.VALID,
+        )
+        subscription = Subscription.objects.get(pk=service.subscription_set.get().pk)
+        payment = subscription.payment_obj
+        payment.paid_invoice = subscription.create_invoice(kind=InvoiceKind.INVOICE)
+        payment.save(update_fields=["paid_invoice"])
+        Customer.objects.filter(pk=service.customer_id).update(
+            vat_validated=timezone.now() - timedelta(days=VAT_VALIDITY_DAYS),
+            vat_validation_state=Customer.VatValidationState.UNKNOWN,
+        )
+
+        with patch("weblate_web.payments.models.validate_vatin") as validate:
+            RecurringPaymentsCommand.handle_subscriptions()
+
+        validate.assert_called_once()
+        repeated = payment.payment_set.get()
+        self.assertEqual(repeated.state, Payment.PROCESSED)
+        self.assertEqual(repeated.amount, subscription.get_renewal_amount())
+        self.assertEqual(cast("Invoice", repeated.draft_invoice).vat_rate, 0)
+        self.assertEqual(cast("Invoice", repeated.paid_invoice).vat_rate, 0)
 
     def test_recurring_payment_rejects_invalid_vat(self) -> None:
         service = self.create_service(years=0, days=-2)
@@ -4715,6 +4747,7 @@ class ServiceTest(FakturaceTestCase):
 
         repeated = subscription.payment_obj.payment_set.get()
         self.assertEqual(repeated.state, Payment.REJECTED)
+        self.assertIsNone(repeated.draft_invoice)
         self.assertEqual(
             repeated.details,
             {

--- a/weblate_web/tests_e2e/test_invoice_screenshots.py
+++ b/weblate_web/tests_e2e/test_invoice_screenshots.py
@@ -102,8 +102,12 @@ def create_customer(case: InvoiceData) -> Customer:
         accounting_reference=case.accounting_reference,
     )
     if case.vat:
-        Customer.objects.filter(pk=customer.pk).update(vat=case.vat)
+        Customer.objects.filter(pk=customer.pk).update(
+            vat=case.vat,
+            vat_validation_state=Customer.VatValidationState.VALID,
+        )
         customer.vat = case.vat
+        customer.vat_validation_state = Customer.VatValidationState.VALID
     return customer
 
 


### PR DESCRIPTION
Only validated EU VAT IDs should qualify for reverse charge. Deriving the initial rate prevents CRM, draft, and direct invoice creation from retaining an unsafe zero-rate default.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
