### PR TITLE
fix(payments): avoid saving unsupported authorization

### DIFF
--- a/weblate_web/payments/backends.py
+++ b/weblate_web/payments/backends.py
@@ -998,7 +998,7 @@ class ThePay2Card(Backend):
             "description_for_customer": self.payment.description,
             "return_url": complete_url,
             "notif_url": complete_url,
-            "save_authorization": bool(self.payment.recurring),
+            "save_authorization": bool(self.payment.recurring and self.recurring),
             "language_code": self.get_language(),
             "customer": {
                 "name": self.payment.customer.name,

--- a/weblate_web/payments/tests.py
+++ b/weblate_web/payments/tests.py
@@ -1221,6 +1221,32 @@ class ThePay2Test(BackendBaseTestCase):
         self.assertEqual(payload["amount"], 61)
 
     @responses.activate
+    def test_recurring_payment_saves_authorization(self) -> None:
+        self.payment.recurring = "y"
+        self.payment.save(update_fields=["recurring"])
+        backend = self.payment.get_payment_backend()
+        thepay_mock_create_payment()
+
+        backend.initiate(None, "", "")
+
+        payload = json.loads(cast("bytes", responses.calls[0].request.body))
+        self.assertIs(payload["save_authorization"], True)
+
+    @responses.activate
+    def test_nonrecurring_method_does_not_save_authorization(self) -> None:
+        self.payment.backend = "thepay2-bitcoin"
+        self.payment.recurring = "y"
+        self.payment.save(update_fields=["backend", "recurring"])
+        backend = self.payment.get_payment_backend()
+        thepay_mock_create_payment()
+
+        backend.initiate(None, "", "")
+
+        payload = json.loads(cast("bytes", responses.calls[0].request.body))
+        self.assertEqual(payload["payment_method_code"], "bitcoin")
+        self.assertIs(payload["save_authorization"], False)
+
+    @responses.activate
     def test_fixed_amount_is_renormalized_before_initiation(self) -> None:
         self.customer.country = "US"
         self.customer.vat = ""


### PR DESCRIPTION
Only request saved authorization when the selected payment backend supports recurring payments. This prevents ThePay from rejecting recurring-intent Bitcoin payments as unavailable.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
