### PR TITLE
feat(crm): flag expired dedicated services

### DIFF
--- a/weblate_web/crm/tests.py
+++ b/weblate_web/crm/tests.py
@@ -650,6 +650,29 @@ class CRMWorkQueueTestCase(BaseCRMTestCase):
         )
         self.assertContains(response, customer.get_absolute_url())
 
+    @override_settings(
+        CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
+    )
+    def test_work_queue_shows_expired_dedicated_followup(self):
+        customer = self.create_customer("EXPIRED DEDICATED CUSTOMER")
+        service = Service.objects.create(customer=customer)
+        CustomerFollowUp.objects.create(
+            customer=customer,
+            service=service,
+            follow_up_at=timezone.now(),
+            type=CustomerFollowUp.Type.EXPIRED_DEDICATED,
+        )
+
+        response = self.client.get(reverse("crm:work-queue"))
+
+        self.assertContains(response, "Stop server")
+        self.assertContains(
+            response,
+            "Stop the dedicated instance because its support contract expired over "
+            "two months ago.",
+        )
+        self.assertContains(response, customer.get_absolute_url())
+
     def test_work_queue_suggests_unpaid_old_invoices_only(self):
         old_invoice = self.create_queue_invoice("OLD INVOICE CUSTOMER", age_days=8)
         fresh_invoice = self.create_queue_invoice("FRESH INVOICE CUSTOMER", age_days=6)

--- a/weblate_web/crm/workqueue.py
+++ b/weblate_web/crm/workqueue.py
@@ -201,6 +201,8 @@ def get_followup_label(followup: CustomerFollowUp, *, due: bool) -> str:
             return _("Locked URL")
         case CustomerFollowUp.Type.OVER_LIMIT:
             return _("Over limits")
+        case CustomerFollowUp.Type.EXPIRED_DEDICATED:
+            return _("Stop server")
     return str(followup.get_type_display())
 
 

--- a/weblate_web/models.py
+++ b/weblate_web/models.py
@@ -87,6 +87,8 @@ SERVICE_LIMIT_FIELDS = (
     "languages",
 )
 
+DEDICATED_CONTRACT_GRACE_PERIOD = timedelta(days=60)
+
 
 ALLOWED_IMAGES = {"image/jpeg", "image/png"}
 PILLOW_VALIDATION_ERRORS = (
@@ -1840,6 +1842,8 @@ class Report(models.Model):
             self.create_locked_site_url_followup()
             return
 
+        self.reconcile_expired_dedicated_followup()
+
         if self.service.status == "hosted" and (
             exceeded_limits := self.service.get_exceeded_limits(self)
         ):
@@ -1903,6 +1907,35 @@ class Report(models.Model):
                     "report_id": self.pk,
                     "site_url": self.site_url,
                     "exceeded_limits": exceeded_limits,
+                },
+            },
+        )
+
+    def reconcile_expired_dedicated_followup(self) -> None:
+        latest_subscription = self.service.hosted_subscriptions.first()
+        if latest_subscription is None:
+            return
+
+        current_time = timezone.now()
+        if latest_subscription.expires > current_time:
+            self.service.followups.filter(
+                type=CustomerFollowUp.Type.EXPIRED_DEDICATED
+            ).delete()
+            return
+        if latest_subscription.expires > current_time - DEDICATED_CONTRACT_GRACE_PERIOD:
+            return
+
+        CustomerFollowUp.objects.update_or_create(
+            service=self.service,
+            type=CustomerFollowUp.Type.EXPIRED_DEDICATED,
+            defaults={
+                "customer": self.service.customer,
+                "follow_up_at": current_time,
+                "details": {
+                    "service_id": self.service_id,
+                    "report_id": self.pk,
+                    "site_url": self.site_url,
+                    "contract_expired_at": latest_subscription.expires.isoformat(),
                 },
             },
         )

--- a/weblate_web/payments/migrations/0006_customerfollowup_expired_dedicated.py
+++ b/weblate_web/payments/migrations/0006_customerfollowup_expired_dedicated.py
@@ -1,0 +1,51 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("payments", "0005_customerfollowup_over_limit")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="customerfollowup",
+            name="type",
+            field=models.PositiveSmallIntegerField(
+                choices=[
+                    (1, "Manual"),
+                    (2, "Duplicate payment"),
+                    (3, "Locked site URL"),
+                    (4, "Service over limits"),
+                    (5, "Expired dedicated service"),
+                ],
+                db_index=True,
+                default=1,
+                verbose_name="Follow-up type",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="customerfollowup",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("service__isnull", False), ("type", 5)),
+                fields=("service", "type"),
+                name="unique_expired_dedicated_followup_per_service",
+            ),
+        ),
+    ]

--- a/weblate_web/payments/models.py
+++ b/weblate_web/payments/models.py
@@ -698,6 +698,7 @@ class CustomerFollowUp(models.Model):
         DUPLICATE_PAYMENT = 2, gettext_lazy("Duplicate payment")
         LOCKED_SITE_URL = 3, gettext_lazy("Locked site URL")
         OVER_LIMIT = 4, gettext_lazy("Service over limits")
+        EXPIRED_DEDICATED = 5, gettext_lazy("Expired dedicated service")
 
     customer = models.ForeignKey(
         Customer, related_name="followups", on_delete=models.deletion.CASCADE
@@ -745,6 +746,11 @@ class CustomerFollowUp(models.Model):
                 condition=models.Q(service__isnull=False, type=4),
                 name="unique_over_limit_followup_per_service",
             ),
+            models.UniqueConstraint(
+                fields=("service", "type"),
+                condition=models.Q(service__isnull=False, type=5),
+                name="unique_expired_dedicated_followup_per_service",
+            ),
         ]
 
     def __str__(self) -> str:
@@ -756,6 +762,11 @@ class CustomerFollowUp(models.Model):
             return self.note
         if self.type == self.Type.OVER_LIMIT:
             return gettext("Review usage and upgrade the dedicated instance.")
+        if self.type == self.Type.EXPIRED_DEDICATED:
+            return gettext(
+                "Stop the dedicated instance because its support contract expired "
+                "over two months ago."
+            )
         return ""
 
 

--- a/weblate_web/tests.py
+++ b/weblate_web/tests.py
@@ -3232,6 +3232,103 @@ class APITest(UserTestCase):  # ruff:ignore[too-many-public-methods]
             service.followups.filter(type=CustomerFollowUp.Type.OVER_LIMIT).exists()
         )
 
+    def test_expired_dedicated_report_creates_stop_followup(self) -> None:
+        Package.objects.create(name="community", verbose="Community support", price=0)
+        package = Package.objects.create(
+            name="dedicated:expired",
+            verbose="Expired dedicated",
+            price=100,
+            category=PackageCategory.PACKAGE_DEDICATED,
+        )
+        customer = Customer.objects.create(user_id=-1, origin=PAYMENTS_ORIGIN)
+        service = Service.objects.create(
+            customer=customer, backup_repository="already-configured"
+        )
+        subscription = service.subscription_set.create(
+            package=package,
+            expires=timezone.now() - timedelta(days=61),
+        )
+
+        self._post_support_report(service, "https://expired.example.com")
+
+        followup = service.followups.get(type=CustomerFollowUp.Type.EXPIRED_DEDICATED)
+        first_followup_id = followup.pk
+        first_report_id = followup.details["report_id"]
+        self.assertEqual(followup.customer, customer)
+        self.assertEqual(followup.details["service_id"], service.pk)
+        self.assertEqual(
+            followup.details["contract_expired_at"], subscription.expires.isoformat()
+        )
+        self.assertEqual(followup.details["site_url"], "https://expired.example.com")
+
+        self._post_support_report(service, "https://expired.example.com")
+
+        followup.refresh_from_db()
+        self.assertEqual(followup.pk, first_followup_id)
+        self.assertNotEqual(followup.details["report_id"], first_report_id)
+        self.assertEqual(
+            service.followups.filter(
+                type=CustomerFollowUp.Type.EXPIRED_DEDICATED
+            ).count(),
+            1,
+        )
+
+        subscription.expires = timezone.now() + timedelta(days=30)
+        subscription.save(update_fields=["expires"])
+        self._post_support_report(service, "https://expired.example.com")
+
+        self.assertFalse(
+            service.followups.filter(
+                type=CustomerFollowUp.Type.EXPIRED_DEDICATED
+            ).exists()
+        )
+
+    def test_dedicated_report_waits_for_contract_grace_period(self) -> None:
+        Package.objects.create(name="community", verbose="Community support", price=0)
+        package = Package.objects.create(
+            name="dedicated:grace",
+            verbose="Dedicated in grace period",
+            price=100,
+            category=PackageCategory.PACKAGE_DEDICATED,
+        )
+        customer = Customer.objects.create(user_id=-1, origin=PAYMENTS_ORIGIN)
+        service = Service.objects.create(customer=customer)
+        service.subscription_set.create(
+            package=package,
+            expires=timezone.now() - timedelta(days=59),
+        )
+
+        self._post_support_report(service, "https://grace.example.com")
+
+        self.assertFalse(
+            service.followups.filter(
+                type=CustomerFollowUp.Type.EXPIRED_DEDICATED
+            ).exists()
+        )
+
+    def test_non_dedicated_report_does_not_create_stop_followup(self) -> None:
+        Package.objects.create(name="community", verbose="Community support", price=0)
+        package = Package.objects.create(
+            name="shared:expired",
+            verbose="Expired shared hosting",
+            price=100,
+            category=PackageCategory.PACKAGE_SHARED,
+        )
+        customer = Customer.objects.create(user_id=-1, origin=PAYMENTS_ORIGIN)
+        service = Service.objects.create(customer=customer)
+        service.subscription_set.create(
+            package=package,
+            expires=timezone.now() - timedelta(days=61),
+        )
+
+        self._post_support_report(service, "https://shared-expired.example.com")
+
+        self.assertFalse(
+            service.followups.filter(
+                type=CustomerFollowUp.Type.EXPIRED_DEDICATED
+            ).exists()
+        )
+
     def test_support_rejects_invalid_report_payload(self) -> None:
         service = self.perform_support()
         report_count = service.report_set.count()


### PR DESCRIPTION
Dedicated servers can remain active long after their contracts expire without an actionable CRM signal. Add a stop-server follow-up after the 60-day grace period and clear it when service is renewed.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
