### PR TITLE
fix(invoices): revalidate VAT before staff issuance

### DIFF
--- a/weblate_web/crm/models.py
+++ b/weblate_web/crm/models.py
@@ -34,6 +34,8 @@ class InteractionQuerySet(models.QuerySet["Interaction", "Interaction"]):
 
 
 class Interaction(models.Model):
+    VIES_OUTAGE_INVOICE_ISSUED = "vies-outage-invoice-issued"
+
     class Origin(models.IntegerChoices):
         EMAIL = 1, "Outbound e-mail"
         MERGE = 2, "Merged customer"
@@ -67,7 +69,7 @@ class Interaction(models.Model):
         ordering = ["-timestamp"]
 
     def __str__(self):
-        return f"{self.timestamp.isoformat()} [{self.customer}:{self.get_origin_display()}]: {self.summary}"
+        return f"{self.timestamp.isoformat()} [{self.customer}:{self.get_origin_display()}]: {self.display_summary}"
 
     @staticmethod
     def _format_detail_value(value: Any) -> object:
@@ -104,7 +106,25 @@ class Interaction(models.Model):
         return self.origin == self.Origin.EMAIL
 
     @property
+    def display_summary(self) -> str:
+        if (
+            self.origin == self.Origin.VIES
+            and self.summary == self.VIES_OUTAGE_INVOICE_ISSUED
+        ):
+            return str(_("Invoice issued during VIES outage"))
+        return self.summary
+
+    @property
     def primary_content(self) -> str:
+        if self.origin == self.Origin.VIES and self.details.get(
+            "stale_validation_used"
+        ):
+            return str(
+                _(
+                    "VIES was temporarily unavailable; the invoice was issued "
+                    "using a recent successful VAT validation."
+                )
+            )
         if self.origin == self.Origin.EMAIL:
             return str(self.details.get("subject") or self.summary)
         if self.content:
@@ -189,8 +209,26 @@ class Interaction(models.Model):
     def _vies_detail_rows(self) -> list[InteractionDetailRow]:
         rows: list[InteractionDetailRow] = []
         self._add_row(rows, _("Automated"), self.details.get("automated"))
+        invoice_id = self.details.get("invoice_id")
+        self._add_row(
+            rows,
+            _("Invoice"),
+            self.details.get("invoice"),
+            self._make_url("crm:invoice-detail", pk=invoice_id) if invoice_id else "",
+        )
+        self._add_row(rows, _("VAT ID"), self.details.get("vat"))
+        self._add_row(rows, _("Previous validation"), self.details.get("validated"))
+        self._add_row(
+            rows,
+            _("Stale validation used"),
+            self.details.get("stale_validation_used"),
+        )
         self._add_row(rows, _("Error code"), self.details.get("code"))
-        self._add_row(rows, _("Error message"), self.details.get("message"))
+        error_message = self.details.get("message")
+        if self.details.get("stale_validation_used"):
+            error_message = _("VIES was temporarily unavailable.")
+        self._add_row(rows, _("Error message"), error_message)
+        self._add_row(rows, _("Issued by"), self.details.get("issued_by"))
         return rows
 
     def _manual_payment_detail_rows(self) -> list[InteractionDetailRow]:

--- a/weblate_web/crm/templates/payments/customer_detail.html
+++ b/weblate_web/crm/templates/payments/customer_detail.html
@@ -460,10 +460,10 @@
                   <td>{{ interaction.timestamp }}</td>
                   <td>{{ interaction.user.username }}</td>
                   <td>{{ interaction.get_origin_display }}</td>
-                  <td>{{ interaction.summary }}</td>
+                  <td>{{ interaction.display_summary }}</td>
                   <td>
                     {% with primary=interaction.primary_content %}
-                      {% if primary and primary != interaction.summary %}{{ primary|linebreaksbr }}{% endif %}
+                      {% if primary and primary != interaction.display_summary %}{{ primary|linebreaksbr }}{% endif %}
                     {% endwith %}
                   </td>
                   <td>

--- a/weblate_web/crm/tests.py
+++ b/weblate_web/crm/tests.py
@@ -11,6 +11,7 @@ import responses
 from django.conf import settings
 from django.contrib.auth.models import Permission, User
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from django.core.management import call_command
 from django.core.management.base import OutputWrapper
@@ -965,6 +966,86 @@ class CRMQuoteStatusTestCase(BaseCRMTestCase):
         self.assertEqual(invoice.customer_reference, "PO-42")
         self.assertEqual(invoice.customer_note, "Approved quote")
         mock_generate_files.assert_called_once_with()
+
+    @patch.object(Invoice, "generate_files")
+    def test_quote_conversion_blocks_failed_vat_validation(self, mock_generate_files):
+        quote = self.create_invoice(Decimal(42), kind=InvoiceKind.QUOTE)
+
+        with patch.object(
+            Customer,
+            "validate_vat_for_issuance",
+            side_effect=ValidationError("Invalid VAT"),
+        ):
+            response = self.client.post(
+                quote.get_absolute_url(),
+                {"confirm_invoice": "1", "invoice": "1"},
+                follow=True,
+            )
+
+        self.assertFalse(quote.invoice_set.exists())
+        self.assertContains(response, "VAT ID could not be validated")
+        mock_generate_files.assert_not_called()
+
+    @patch.object(Invoice, "generate_files")
+    def test_quote_conversion_records_vat_outage(self, mock_generate_files):
+        quote = self.create_invoice(Decimal(42), kind=InvoiceKind.QUOTE)
+        Customer.objects.filter(pk=quote.customer.pk).update(
+            vat="DE136695976", vat_validated=timezone.now()
+        )
+        quote.customer.refresh_from_db()
+        warning = ValidationError(
+            '<a href="https://example.com/status">Localized VIES warning</a>',
+            code="MS_UNAVAILABLE",
+        )
+
+        with patch.object(Customer, "validate_vat_for_issuance", return_value=warning):
+            response = self.client.post(
+                quote.get_absolute_url(),
+                {"confirm_invoice": "1", "invoice": "1"},
+                follow=True,
+            )
+
+        invoice = quote.invoice_set.get()
+        interaction = Interaction.objects.get(customer=quote.customer)
+        self.assertEqual(interaction.summary, Interaction.VIES_OUTAGE_INVOICE_ISSUED)
+        self.assertEqual(interaction.content, "")
+        self.assertEqual(interaction.details["invoice"], invoice.number)
+        self.assertTrue(interaction.details["stale_validation_used"])
+        self.assertNotIn("message", interaction.details)
+        self.assertIn("Invoice issued during VIES outage", str(interaction))
+        self.assertNotIn(Interaction.VIES_OUTAGE_INVOICE_ISSUED, str(interaction))
+        detail_rows = {
+            str(row.label): (str(row.value), row.url) for row in interaction.detail_rows
+        }
+        self.assertEqual(detail_rows["Automated"][0], "No")
+        self.assertEqual(
+            detail_rows["Invoice"],
+            (invoice.number, invoice.get_absolute_url()),
+        )
+        self.assertEqual(detail_rows["VAT ID"][0], "DE136695976")
+        self.assertEqual(detail_rows["Stale validation used"][0], "Yes")
+        self.assertEqual(detail_rows["Error code"][0], "MS_UNAVAILABLE")
+        self.assertEqual(
+            detail_rows["Error message"][0], "VIES was temporarily unavailable."
+        )
+        self.assertContains(response, "VIES is temporarily unavailable")
+        mock_generate_files.assert_called_once_with()
+
+        response = self.client.get(
+            quote.customer.get_absolute_url(), {"tab": "interactions"}
+        )
+        self.assertContains(response, "Invoice issued during VIES outage")
+        self.assertContains(response, "VIES was temporarily unavailable")
+        self.assertNotContains(response, Interaction.VIES_OUTAGE_INVOICE_ISSUED)
+        self.assertNotContains(response, "Localized VIES warning")
+
+        response = self.client.get(
+            reverse("crm:interaction-detail", kwargs={"pk": interaction.pk})
+        )
+        self.assertContains(response, "Invoice issued during VIES outage")
+        self.assertContains(response, "VIES was temporarily unavailable.")
+        self.assertNotContains(response, Interaction.VIES_OUTAGE_INVOICE_ISSUED)
+        self.assertNotContains(response, "Localized VIES warning")
 
     def test_invoice_detail_breadcrumb_links_to_kind_list(self):
         quote = self.create_invoice(Decimal(42), kind=InvoiceKind.QUOTE)
@@ -2437,6 +2518,111 @@ class CRMTestCase(BaseCRMTestCase):
         self.assertEqual(response.status_code, 404)
 
 
+class CRMVATIssuanceTestCase(BaseCRMTestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser(
+            username="admin", email="admin@example.com"
+        )
+        self.client.force_login(self.user)
+
+    def test_service_invoice_blocks_failed_vat_validation(self):
+        Package.objects.create(name="community", price=0)
+        package = Package.objects.create(name="x1", verbose="pkg1", price=42)
+        customer = self.create_customer()
+        payment = Payment.objects.create(customer=customer, amount=1)
+        service = Service.objects.create(customer=customer)
+        subscription = service.subscription_set.create(
+            package=package,
+            expires=timezone.now() + timedelta(days=30),
+            payment=payment,
+        )
+
+        with patch.object(
+            Customer,
+            "validate_vat_for_issuance",
+            side_effect=ValidationError("Invalid VAT"),
+        ):
+            response = self.client.post(
+                service.get_absolute_url(),
+                {
+                    "action": "renewal",
+                    "kind": InvoiceKind.INVOICE,
+                    "subscription": subscription.pk,
+                    "confirm_invoice": "1",
+                },
+                follow=True,
+            )
+
+        self.assertFalse(Invoice.objects.exists())
+        self.assertContains(response, "VAT ID could not be validated")
+
+    def test_customer_invoice_blocks_failed_vat_validation(self):
+        package = Package.objects.create(name="x1", verbose="pkg1", price=42)
+        customer = self.create_customer()
+
+        with patch.object(
+            Customer,
+            "validate_vat_for_issuance",
+            side_effect=ValidationError("Invalid VAT"),
+        ):
+            response = self.client.post(
+                customer.get_absolute_url(),
+                {
+                    "package": package.pk,
+                    "currency": Currency.EUR,
+                    "kind": InvoiceKind.INVOICE,
+                    "confirm_invoice": "1",
+                },
+                follow=True,
+            )
+
+        self.assertFalse(Invoice.objects.exists())
+        self.assertContains(response, "VAT ID could not be validated")
+
+    @patch.object(Invoice, "generate_files")
+    def test_service_invoice_records_vat_outage(self, generate_files):
+        Package.objects.create(name="community", price=0)
+        package = Package.objects.create(
+            name="x1",
+            verbose="pkg1",
+            price=42,
+            category=PackageCategory.PACKAGE_SHARED,
+        )
+        customer = self.create_customer()
+        Customer.objects.filter(pk=customer.pk).update(
+            vat="DE136695976", vat_validated=timezone.now()
+        )
+        customer.refresh_from_db()
+        payment = Payment.objects.create(customer=customer, amount=1)
+        service = Service.objects.create(customer=customer)
+        subscription = service.subscription_set.create(
+            package=package,
+            expires=timezone.now() + timedelta(days=30),
+            payment=payment,
+        )
+        warning = ValidationError("VIES unavailable", code="MS_UNAVAILABLE")
+
+        with patch.object(Customer, "validate_vat_for_issuance", return_value=warning):
+            response = self.client.post(
+                service.get_absolute_url(),
+                {
+                    "action": "renewal",
+                    "kind": InvoiceKind.INVOICE,
+                    "subscription": subscription.pk,
+                    "confirm_invoice": "1",
+                },
+                follow=True,
+            )
+
+        invoice = Invoice.objects.get()
+        interaction = Interaction.objects.get(customer=customer)
+        self.assertRedirects(response, invoice.get_absolute_url())
+        self.assertContains(response, "VIES is temporarily unavailable")
+        self.assertEqual(interaction.details["invoice"], invoice.number)
+        self.assertEqual(interaction.details["code"], "MS_UNAVAILABLE")
+        generate_files.assert_called_once_with()
+
+
 @override_settings(  # ruff:ignore[too-many-public-methods]
     CACHES={
         "default": {
@@ -3708,20 +3894,27 @@ class IncomeTrackingTestCase(BaseCRMTestCase):
         self.assertEqual(subscription.package, current)
         self.assertEqual(Invoice.objects.count(), 0)
 
-        response = self.client.post(
-            reverse("crm:service-detail", kwargs={"pk": service.pk}),
-            {
-                "subscription": subscription.pk,
-                "package": target.name,
-                "action": "upgrade",
-                "kind": InvoiceKind.QUOTE,
-                "customer_reference": "",
-                "customer_note": "",
-            },
-            follow=True,
-        )
+        with patch.object(
+            Customer,
+            "validate_vat_for_issuance",
+            side_effect=ValidationError("Invalid VAT"),
+        ) as validate_vat:
+            response = self.client.post(
+                reverse("crm:service-detail", kwargs={"pk": service.pk}),
+                {
+                    "subscription": subscription.pk,
+                    "package": target.name,
+                    "action": "upgrade",
+                    "kind": InvoiceKind.INVOICE,
+                    "customer_reference": "",
+                    "customer_note": "",
+                    "confirm_invoice": "1",
+                },
+                follow=True,
+            )
 
         self.assertRedirects(response, service.get_absolute_url())
+        validate_vat.assert_not_called()
         subscription.refresh_from_db()
         self.assertEqual(subscription.package, target)
         self.assertEqual(subscription.payment, payment)

--- a/weblate_web/crm/views.py
+++ b/weblate_web/crm/views.py
@@ -11,7 +11,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import DataError, IntegrityError, transaction
 from django.db.models import (
     Case,
@@ -100,6 +100,48 @@ if TYPE_CHECKING:
     from django.http import HttpRequest
 
     from weblate_web.views import AuthenticatedHttpRequest
+
+
+def _validate_vat_for_invoice(
+    request: HttpRequest, customer: Customer
+) -> tuple[bool, ValidationError | None]:
+    try:
+        return True, customer.validate_vat_for_issuance()
+    except ValidationError:
+        messages.error(
+            request,
+            gettext(
+                "The customer's VAT ID could not be validated, so the invoice "
+                "was not issued. Update the customer data or try again later."
+            ),
+        )
+        return False, None
+
+
+def _record_vat_issuance_warning(
+    request: HttpRequest,
+    customer: Customer,
+    invoice: Invoice,
+    warning: ValidationError,
+) -> None:
+    customer.record_stale_vat_issuance(
+        invoice=invoice,
+        user=cast("User", request.user),
+        warning=warning,
+    )
+    validated = gettext("an earlier successful check")
+    if customer.vat_validated is not None:
+        validated = timezone.localtime(customer.vat_validated).strftime(
+            "%Y-%m-%d %H:%M %Z"
+        )
+    messages.warning(
+        request,
+        gettext(
+            "VIES is temporarily unavailable. The invoice was issued using the "
+            "VAT validation from %(validated)s."
+        )
+        % {"validated": validated},
+    )
 
 
 IncomeCategory: TypeAlias = InvoiceCategory | None
@@ -328,6 +370,14 @@ class ServiceDetailView(CRMMixin, DetailView[Service]):  # type: ignore[misc]
             if response is not None:
                 return response
 
+        vat_warning = None
+        if kind == InvoiceKind.INVOICE:
+            vat_valid, vat_warning = _validate_vat_for_invoice(
+                request, service.customer
+            )
+            if not vat_valid:
+                return redirect(service)
+
         with override("en"):
             kwargs = {
                 "kind": kind,
@@ -346,6 +396,10 @@ class ServiceDetailView(CRMMixin, DetailView[Service]):  # type: ignore[misc]
                     ),
                 )
                 return redirect(service)
+        if vat_warning is not None:
+            _record_vat_issuance_warning(
+                request, service.customer, invoice, vat_warning
+            )
         return redirect(invoice)
 
     def post(self, request, *args, **kwargs):
@@ -637,6 +691,26 @@ class InvoiceDetailView(CRMMixin, DetailView[Invoice]):  # type: ignore[misc]
             return self.reopen_quote(request)
         return None
 
+    def convert_quote(
+        self,
+        request: HttpRequest,
+        quote: Invoice,
+        convert_form: CustomerReferenceForm,
+    ):
+        vat_valid, vat_warning = _validate_vat_for_invoice(request, quote.customer)
+        if not vat_valid:
+            return redirect(quote)
+        with override("en"):
+            invoice = quote.duplicate(
+                kind=InvoiceKind.INVOICE,
+                customer_reference=convert_form.cleaned_data["customer_reference"],
+                customer_note=convert_form.cleaned_data["customer_note"],
+            )
+            invoice.generate_files()
+        if vat_warning is not None:
+            _record_vat_issuance_warning(request, quote.customer, invoice, vat_warning)
+        return redirect(invoice)
+
     def post(self, request, *args, **kwargs):
         self.object = self.get_object()
         if quote_status_response := self.handle_quote_status_post(
@@ -666,14 +740,7 @@ class InvoiceDetailView(CRMMixin, DetailView[Invoice]):  # type: ignore[misc]
             and self.can_convert()
             and has_invoice_confirmation(request)
         ):
-            with override("en"):
-                invoice = quote.duplicate(
-                    kind=InvoiceKind.INVOICE,
-                    customer_reference=convert_form.cleaned_data["customer_reference"],
-                    customer_note=convert_form.cleaned_data["customer_note"],
-                )
-                invoice.generate_files()
-            return redirect(invoice)
+            return self.convert_quote(request, quote, convert_form)
         return self.get(request, *args, **kwargs)
 
 
@@ -1056,9 +1123,15 @@ class CustomerDetailView(CRMMixin, DetailView[Customer]):  # type: ignore[misc]
     def create_new_subscription(self, request, customer: Customer):
         subscription_form = NewSubscriptionForm(request.POST)
         if subscription_form.is_valid():
+            kind = subscription_form.cleaned_data["kind"]
+            vat_warning = None
+            if kind == InvoiceKind.INVOICE:
+                vat_valid, vat_warning = _validate_vat_for_invoice(request, customer)
+                if not vat_valid:
+                    return redirect(customer)
             with override("en"):
                 invoice = Subscription.new_subscription_invoice(
-                    kind=subscription_form.cleaned_data["kind"],
+                    kind=kind,
                     customer=customer,
                     package=subscription_form.cleaned_data["package"],
                     currency=subscription_form.cleaned_data["currency"],
@@ -1068,6 +1141,8 @@ class CustomerDetailView(CRMMixin, DetailView[Customer]):  # type: ignore[misc]
                     customer_note=subscription_form.cleaned_data["customer_note"],
                     skip_intro=subscription_form.cleaned_data.get("skip_intro", False),
                 )
+            if vat_warning is not None:
+                _record_vat_issuance_warning(request, customer, invoice, vat_warning)
             return redirect(invoice)
 
         return self.get(request)
@@ -1136,7 +1211,7 @@ class InteractionDetailView(CRMMixin, DetailView[Interaction]):  # type: ignore[
     title = "Interaction detail"
 
     def get_title(self) -> str:
-        return self.object.summary
+        return self.object.display_summary
 
 
 class InteractionDownloadView(InteractionDetailView):

--- a/weblate_web/invoices/admin.py
+++ b/weblate_web/invoices/admin.py
@@ -19,13 +19,17 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.utils import timezone
+from django.utils.translation import gettext
 
+from .forms import InvoiceAdminForm
 from .models import Discount, Invoice, InvoiceItem, InvoiceKind
 
 if TYPE_CHECKING:
+    from django.contrib.auth.models import User
     from django.http.request import HttpRequest
 
 
@@ -43,6 +47,7 @@ class InvoiceItemAdmin(admin.TabularInline):
 
 @admin.register(Invoice)
 class InvoiceAdmin(admin.ModelAdmin):
+    form = InvoiceAdminForm
     date_hierarchy = "issue_date"
     ordering = ("-issue_date",)
     autocomplete_fields = ("customer", "parent")
@@ -68,6 +73,24 @@ class InvoiceAdmin(admin.ModelAdmin):
                 invoice.prepaid = True
                 invoice.save(update_fields=["prepaid"])
             invoice.generate_files()
+        if form.vat_validation_warning is not None:
+            invoice.customer.record_stale_vat_issuance(
+                invoice=invoice,
+                user=cast("User", request.user),
+                warning=form.vat_validation_warning,
+            )
+            validated = timezone.localtime(invoice.customer.vat_validated).strftime(
+                "%Y-%m-%d %H:%M %Z"
+            )
+            self.message_user(
+                request,
+                gettext(
+                    "VIES is temporarily unavailable. The invoice was issued using "
+                    "the VAT validation from %(validated)s."
+                )
+                % {"validated": validated},
+                level=messages.WARNING,
+            )
 
     def view_on_site(self, obj: Invoice) -> str | None:
         return obj.get_download_url()

--- a/weblate_web/invoices/forms.py
+++ b/weblate_web/invoices/forms.py
@@ -20,8 +20,56 @@
 from __future__ import annotations
 
 from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext
 
-from .models import Invoice
+from .models import Invoice, InvoiceKind
+
+
+class InvoiceAdminForm(forms.ModelForm):
+    vat_validation_warning: ValidationError | None = None
+
+    class Meta:
+        fields = (
+            "issue_date",
+            "due_date",
+            "tax_date",
+            "kind",
+            "category",
+            "customer",
+            "customer_reference",
+            "customer_note",
+            "quote_status",
+            "quote_status_note",
+            "discount",
+            "vat_rate",
+            "currency",
+            "parent",
+            "prepaid",
+            "extra",
+        )
+        model = Invoice
+
+    def clean(self):
+        cleaned_data = super().clean() or {}
+        customer = cleaned_data.get("customer")
+        if (
+            self.instance._state.adding  # pylint: disable=protected-access
+            and cleaned_data.get("kind") == InvoiceKind.INVOICE
+            and customer is not None
+        ):
+            try:
+                self.vat_validation_warning = customer.validate_vat_for_issuance()
+            except ValidationError:
+                self.add_error(
+                    "customer",
+                    gettext(
+                        "The customer's VAT ID could not be validated, so the "
+                        "invoice was not issued. Update the customer data or try "
+                        "again later."
+                    ),
+                )
+        return cleaned_data
 
 
 class CustomerReferenceForm(forms.ModelForm):

--- a/weblate_web/management/commands/background_vat.py
+++ b/weblate_web/management/commands/background_vat.py
@@ -17,10 +17,36 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 from django.core.management.base import BaseCommand
 
 from weblate_web.remote import fetch_vat_info
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@contextmanager
+def silence_vat_loggers() -> Iterator[None]:
+    """Suppress noisy VIES and Zeep output for this background command."""
+    loggers = [logging.getLogger(name) for name in ("vies", "zeep")]
+    original_configuration = [
+        (logger, logger.handlers, logger.propagate) for logger in loggers
+    ]
+    try:
+        for logger in loggers:
+            logger.handlers = [logging.NullHandler()]
+            logger.propagate = False
+        yield
+    finally:
+        for logger, handlers, propagate in original_configuration:
+            logger.handlers = handlers
+            logger.propagate = propagate
 
 
 class Command(BaseCommand):
@@ -41,4 +67,5 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options) -> None:
-        fetch_vat_info(fetch_all=options["all"], delay=options["delay"])
+        with silence_vat_loggers():
+            fetch_vat_info(fetch_all=options["all"], delay=options["delay"])

--- a/weblate_web/payments/models.py
+++ b/weblate_web/payments/models.py
@@ -105,6 +105,7 @@ VAT_COUNTRY_CODE_ALIASES = {
     "XI": "GB",
 }
 VAT_RATE = 21
+VAT_ISSUANCE_GRACE_DAYS = 30
 DELETED_MAIL = re.compile(r"noreply\+[0-9]+@weblate.org")
 PAYMENT_QUANTUM = Decimal("0.01")
 
@@ -655,21 +656,26 @@ class Customer(models.Model):
             and self.vat_validation_error.get("vat") == str(self.vat)
         )
 
-    def prepayment_validation(self, *, automated: bool = False):
+    def prepayment_validation(
+        self, *, automated: bool = False, force: bool = False
+    ) -> None:
         # ruff:ignore[import-outside-top-level]
         from weblate_web.crm.models import Interaction
 
         # Skip payment originated validation if we have validated recently
-        if not automated and self.vat_recently_validated:
+        if not force and not automated and self.vat_recently_validated:
             # Perform offline validation only
             validate_vatin_offline(self.vat)
             return
-        if automated and self.vat_recently_invalid:
+        if not force and automated and self.vat_recently_invalid:
             return
 
         previous_state = self.vat_validation_state
         try:
-            validate_vatin(self.vat, force=not automated and self.vat_recently_invalid)
+            validate_vatin(
+                self.vat,
+                force=force or (not automated and self.vat_recently_invalid),
+            )
         except ValidationError as error:
             if is_vies_transient_validation_error(error):
                 raise
@@ -690,6 +696,57 @@ class Customer(models.Model):
             raise
         self._set_vat_valid()
         self.save(update_fields=self._vat_validation_update_fields)
+
+    def validate_vat_for_issuance(self) -> ValidationError | None:
+        """Validate reverse-charge eligibility before issuing an invoice."""
+        if not (self.is_eu and self.country_code != "CZ" and self.vat):
+            return None
+
+        if self.vat_recently_validated:
+            self.prepayment_validation()
+            return None
+
+        previously_valid = self.has_valid_vat
+        previous_validation = self.vat_validated
+        try:
+            self.prepayment_validation(force=True)
+        except ValidationError as error:
+            if (
+                is_vies_transient_validation_error(error)
+                and previously_valid
+                and previous_validation is not None
+                and previous_validation
+                >= timezone.now() - timedelta(days=VAT_ISSUANCE_GRACE_DAYS)
+            ):
+                return error
+            raise
+        return None
+
+    def record_stale_vat_issuance(
+        self, *, invoice: Invoice, user: User, warning: ValidationError
+    ) -> None:
+        """Record an invoice issued during a transient VIES outage."""
+        # ruff:ignore[import-outside-top-level]
+        from weblate_web.crm.models import Interaction
+
+        self.interaction_set.create(
+            origin=Interaction.Origin.VIES,
+            summary=Interaction.VIES_OUTAGE_INVOICE_ISSUED,
+            content="",
+            details={
+                "automated": False,
+                "invoice": invoice.number,
+                "invoice_id": str(invoice.pk),
+                "vat": str(self.vat),
+                "validated": self.vat_validated.isoformat()
+                if self.vat_validated
+                else None,
+                "stale_validation_used": True,
+                "code": str(warning.code) if warning.code else "",
+                "issued_by": user.get_username(),
+            },
+            user=user,
+        )
 
 
 class CustomerFollowUp(models.Model):

--- a/weblate_web/payments/tests.py
+++ b/weblate_web/payments/tests.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import json
 from copy import deepcopy
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 from typing import Any, cast
 from unittest.mock import patch
@@ -48,7 +48,12 @@ from weblate_web.tests import (
 )
 
 from .backends import FioBank, InvalidState, PaymentError, get_backend, list_backends
-from .models import Customer, CustomerFollowUp, Payment
+from .models import (
+    VAT_ISSUANCE_GRACE_DAYS,
+    Customer,
+    CustomerFollowUp,
+    Payment,
+)
 from .validators import validate_vatin
 
 CUSTOMER = {
@@ -297,6 +302,107 @@ class ModelObjectsTestCase(TestCase):
         customer.vat = cast("str", CUSTOMER["vat"])
         customer.vat_validation_state = Customer.VatValidationState.VALID
         return customer
+
+    def create_foreign_eu_customer_for_vat_validation(
+        self,
+        *,
+        state: Customer.VatValidationState = Customer.VatValidationState.VALID,
+        age: timedelta = timedelta(days=VAT_ISSUANCE_GRACE_DAYS),
+    ) -> Customer:
+        customer = self.create_customer_for_vat_validation()
+        Customer.objects.filter(pk=customer.pk).update(
+            country="DE",
+            vat="DE136695976",
+            vat_validated=timezone.now() - age,
+            vat_validation_state=state,
+            vat_validation_error={},
+        )
+        customer.refresh_from_db()
+        return customer
+
+    def test_vat_issuance_accepts_recent_validation(self) -> None:
+        customer = self.create_foreign_eu_customer_for_vat_validation(
+            age=timedelta(days=1)
+        )
+
+        with patch("weblate_web.payments.models.validate_vatin") as validate:
+            warning = customer.validate_vat_for_issuance()
+
+        self.assertIsNone(warning)
+        validate.assert_not_called()
+
+    def test_vat_issuance_forces_stale_validation(self) -> None:
+        customer = self.create_foreign_eu_customer_for_vat_validation(
+            age=timedelta(days=8)
+        )
+
+        with patch("weblate_web.payments.models.validate_vatin") as validate:
+            warning = customer.validate_vat_for_issuance()
+
+        self.assertIsNone(warning)
+        self.assertEqual(validate.call_args.kwargs, {"force": True})
+        customer.refresh_from_db()
+        self.assertTrue(customer.vat_recently_validated)
+
+    def test_vat_issuance_allows_recent_valid_state_during_outage(self) -> None:
+        customer = self.create_foreign_eu_customer_for_vat_validation(
+            age=timedelta(days=VAT_ISSUANCE_GRACE_DAYS - 1)
+        )
+        error = ValidationError("Temporary VIES failure", code="MS_UNAVAILABLE")
+
+        with patch(
+            "weblate_web.payments.models.validate_vatin", side_effect=error
+        ) as validate:
+            warning = customer.validate_vat_for_issuance()
+
+        self.assertIs(warning, error)
+        self.assertEqual(validate.call_args.kwargs, {"force": True})
+        customer.refresh_from_db()
+        self.assertEqual(
+            customer.vat_validation_state, customer.VatValidationState.VALID
+        )
+
+    def test_vat_issuance_blocks_old_valid_state_during_outage(self) -> None:
+        customer = self.create_foreign_eu_customer_for_vat_validation(
+            age=timedelta(days=VAT_ISSUANCE_GRACE_DAYS + 1)
+        )
+        error = ValidationError("Temporary VIES failure", code="MS_UNAVAILABLE")
+
+        with (
+            patch("weblate_web.payments.models.validate_vatin", side_effect=error),
+            self.assertRaises(ValidationError),
+        ):
+            customer.validate_vat_for_issuance()
+
+    def test_vat_issuance_blocks_unknown_state_during_outage(self) -> None:
+        customer = self.create_foreign_eu_customer_for_vat_validation(
+            state=Customer.VatValidationState.UNKNOWN,
+            age=timedelta(days=1),
+        )
+        error = ValidationError("Temporary VIES failure", code="MS_UNAVAILABLE")
+
+        with (
+            patch("weblate_web.payments.models.validate_vatin", side_effect=error),
+            self.assertRaises(ValidationError),
+        ):
+            customer.validate_vat_for_issuance()
+
+    def test_vat_issuance_blocks_definitively_invalid_vat(self) -> None:
+        customer = self.create_foreign_eu_customer_for_vat_validation(
+            age=timedelta(days=8)
+        )
+        error = ValidationError("Invalid VAT", code="Invalid VAT")
+
+        with (
+            patch("weblate_web.payments.models.validate_vatin", side_effect=error),
+            self.assertRaises(ValidationError),
+        ):
+            customer.validate_vat_for_issuance()
+
+        customer.refresh_from_db()
+        self.assertEqual(
+            customer.vat_validation_state, Customer.VatValidationState.INVALID
+        )
 
     def test_merge(self) -> None:
         customer = Customer.objects.create(**CUSTOMER)

--- a/weblate_web/remote.py
+++ b/weblate_web/remote.py
@@ -200,6 +200,6 @@ def fetch_vat_info(*, fetch_all: bool = False, delay: int = 30) -> None:
 
         # Actually fetch data
         try:
-            customer.prepayment_validation(automated=True)
+            customer.prepayment_validation(automated=True, force=True)
         except ValidationError:
             continue

--- a/weblate_web/test_admin.py
+++ b/weblate_web/test_admin.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 from django.contrib import admin
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.test import RequestFactory, TestCase
 from django.utils import timezone
 
@@ -16,7 +17,9 @@ from weblate_web.admin import (
 )
 from weblate_web.admin_app import CustomAdminConfig
 from weblate_web.admin_site import UserAutocompleteJsonView
+from weblate_web.crm.models import Interaction
 from weblate_web.invoices.admin import InvoiceAdmin
+from weblate_web.invoices.forms import InvoiceAdminForm
 from weblate_web.invoices.models import (
     Invoice,
     InvoiceCategory,
@@ -175,8 +178,44 @@ class InvoiceAdminTestCase(TestCase):
     def make_mock_form(self, invoice: Invoice):
         form = Mock()
         form.instance = invoice
+        form.vat_validation_warning = None
         form.save_m2m = lambda: None
         return form
+
+    def get_form_data(self, customer: Customer) -> dict[str, object]:
+        return {
+            "issue_date": timezone.localdate(),
+            "kind": InvoiceKind.INVOICE,
+            "category": InvoiceCategory.HOSTING,
+            "customer": customer.pk,
+            "quote_status": 0,
+            "vat_rate": 21,
+            "currency": 0,
+            "extra": "{}",
+        }
+
+    def test_add_form_blocks_failed_vat_validation(self) -> None:
+        customer = self.create_customer()
+        with patch.object(
+            Customer,
+            "validate_vat_for_issuance",
+            side_effect=ValidationError("Invalid VAT"),
+        ):
+            form = InvoiceAdminForm(data=self.get_form_data(customer))
+            is_valid = form.is_valid()
+
+        self.assertFalse(is_valid)
+        self.assertIn("customer", form.errors)
+
+    def test_add_form_preserves_vat_outage_warning(self) -> None:
+        customer = self.create_customer()
+        warning = ValidationError("VIES unavailable", code="MS_UNAVAILABLE")
+        with patch.object(Customer, "validate_vat_for_issuance", return_value=warning):
+            form = InvoiceAdminForm(data=self.get_form_data(customer))
+            is_valid = form.is_valid()
+
+        self.assertTrue(is_valid, form.errors)
+        self.assertIs(form.vat_validation_warning, warning)
 
     def test_has_delete_permission_always_false(self) -> None:
         request = self.factory.get("/")
@@ -296,4 +335,33 @@ class InvoiceAdminTestCase(TestCase):
 
         invoice.refresh_from_db()
         self.assertFalse(invoice.prepaid)
+        mock_generate.assert_called_once()
+
+    @patch.object(Invoice, "generate_files")
+    def test_save_related_records_vat_outage(self, mock_generate) -> None:
+        invoice = self.create_invoice(kind=InvoiceKind.INVOICE)
+        invoice.invoiceitem_set.create(description="Service", unit_price=100)
+        invoice.customer.vat = "DE136695976"
+        invoice.customer.vat_validated = timezone.now()
+
+        request = self.factory.get("/")
+        request.user = self.user
+        form = self.make_mock_form(invoice)
+        form.vat_validation_warning = ValidationError(
+            "VIES unavailable", code="MS_UNAVAILABLE"
+        )
+
+        with patch.object(self.invoice_admin, "message_user") as message_user:
+            self.invoice_admin.save_related(request, form, formsets=[], change=False)
+
+        interaction = Interaction.objects.get(customer=invoice.customer)
+        self.assertEqual(interaction.origin, Interaction.Origin.VIES)
+        self.assertEqual(interaction.summary, Interaction.VIES_OUTAGE_INVOICE_ISSUED)
+        self.assertEqual(interaction.content, "")
+        self.assertEqual(interaction.details["invoice"], invoice.number)
+        self.assertEqual(interaction.details["vat"], "DE136695976")
+        self.assertTrue(interaction.details["stale_validation_used"])
+        self.assertNotIn("message", interaction.details)
+        self.assertEqual(interaction.user, self.user)
+        message_user.assert_called_once()
         mock_generate.assert_called_once()

--- a/weblate_web/tests.py
+++ b/weblate_web/tests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
@@ -2065,7 +2066,7 @@ class PaymentsTest(FakturaceTestCase):
         )
         self.assertTrue(
             all(
-                call.kwargs == {"automated": True}
+                call.kwargs == {"automated": True, "force": True}
                 for call in prepayment_validation.call_args_list
             )
         )
@@ -2081,6 +2082,55 @@ class PaymentsTest(FakturaceTestCase):
         self.assertEqual(
             {call.args[0].pk for call in prepayment_validation.call_args_list},
             {recent.pk},
+        )
+        self.assertEqual(
+            prepayment_validation.call_args.kwargs,
+            {"automated": True, "force": True},
+        )
+
+    def test_background_vat_silences_vies_and_zeep_logs(self) -> None:
+        def noisy_fetch(*, fetch_all: bool, delay: int) -> None:
+            logging.getLogger("vies").error("MS_MAX_CONCURRENT_REQ")
+            logging.getLogger("zeep.wsdl.bindings.soap").warning(
+                "Forcing soap:address location to HTTPS"
+            )
+
+        with (
+            patch(
+                "weblate_web.management.commands.background_vat.fetch_vat_info",
+                side_effect=noisy_fetch,
+            ),
+            self.assertNoLogs(level="WARNING"),
+        ):
+            call_command("background_vat", delay=0)
+
+    def test_background_vat_restores_loggers_after_failure(self) -> None:
+        vies_logger = logging.getLogger("vies")
+        zeep_logger = logging.getLogger("zeep")
+        original_configuration = (
+            list(vies_logger.handlers),
+            vies_logger.propagate,
+            list(zeep_logger.handlers),
+            zeep_logger.propagate,
+        )
+
+        with (
+            patch(
+                "weblate_web.management.commands.background_vat.fetch_vat_info",
+                side_effect=RuntimeError("Unexpected failure"),
+            ),
+            self.assertRaises(RuntimeError),
+        ):
+            call_command("background_vat", delay=0)
+
+        self.assertEqual(
+            (
+                vies_logger.handlers,
+                vies_logger.propagate,
+                zeep_logger.handlers,
+                zeep_logger.propagate,
+            ),
+            original_configuration,
         )
 
     def test_prefetch_vat_transient_errors_retry_without_interaction(self) -> None:
@@ -2138,7 +2188,7 @@ class PaymentsTest(FakturaceTestCase):
             },
         )
         self.assertEqual(customer.interaction_set.count(), 0)
-        self.assertEqual(validate.call_count, 1)
+        self.assertEqual(validate.call_count, 2)
 
     def test_prefetch_vat_valid_to_invalid_creates_interaction(self) -> None:
         customer = self.create_vat_customer()


### PR DESCRIPTION
Prevent stale VIES results from granting reverse charge indefinitely while allowing recently validated customers through transient outages. Keep background refreshes quiet and persist locale-independent CRM audit data.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
