### PR TITLE
feat(activity): retain instance activity and flag sustained drops

### DIFF
--- a/weblate_web/activity.py
+++ b/weblate_web/activity.py
@@ -1,0 +1,149 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from dateutil.relativedelta import relativedelta
+from django.db import transaction
+from django.db.models import Q
+from django.utils import timezone
+
+from weblate_web.models import PackageCategory, Service, ServiceActivity, ServiceKind
+from weblate_web.payments.models import CustomerFollowUp
+
+if TYPE_CHECKING:
+    from datetime import date
+
+    from weblate_web.models import Report
+
+
+@transaction.atomic
+def record_activity(report: Report, activity: dict[date, int]) -> None:
+    """Merge reported months while serializing activity and episode updates."""
+    service = Service.objects.select_for_update().get(pk=report.service_id)
+    report.service = service
+    if not activity or not report.is_valid_site_url():
+        return
+    for month, changes in activity.items():
+        ServiceActivity.objects.update_or_create(
+            service=service, month=month, defaults={"changes": changes}
+        )
+    if (
+        service.kind != ServiceKind.SERVICE
+        or not service.subscription_set.filter(
+            Q(
+                package__category__in=[
+                    PackageCategory.PACKAGE_DEDICATED,
+                    PackageCategory.PACKAGE_SHARED,
+                    PackageCategory.PACKAGE_SUPPORT,
+                ]
+            )
+            | Q(package__name="backup"),
+            enabled=True,
+            expires__gte=timezone.now(),
+        ).exists()
+    ):
+        return
+    reconcile_activity_drop(report)
+
+
+def reconcile_activity_drop(report: Report) -> None:
+    """Open one follow-up per sustained drop, until actual activity recovers."""
+    service = report.service
+    latest_month = timezone.localdate().replace(day=1) - relativedelta(months=1)
+    months = [
+        latest_month - relativedelta(months=offset) for offset in range(4, -1, -1)
+    ]
+    counts = dict(
+        service.activity.filter(month__in=months).values_list("month", "changes")
+    )
+    if latest_month not in counts:
+        return
+    state = service.activity_drop_state
+    followups = service.followups.filter(type=CustomerFollowUp.Type.ACTIVITY_DROP)
+    if "baseline_sum" in state:
+        # Keep the original baseline: a shrinking rolling average is not recovery.
+        recovery_month = (
+            service.activity.filter(
+                month__gt=state["detected_month"],
+                month__lte=latest_month,
+                changes__gt=state["baseline_sum"] // 6,
+            )
+            .order_by("-month")
+            .values_list("month", flat=True)
+            .first()
+        )
+        if recovery_month is not None:
+            followups.delete()
+            state = service.activity_drop_state = {
+                "recovered_month": recovery_month.isoformat()
+            }
+            service.save(update_fields=["activity_drop_state"])
+        else:
+            followups.update(
+                details={
+                    **state,
+                    "report_id": report.pk,
+                    "latest_month": latest_month.isoformat(),
+                    "latest_changes": counts[latest_month],
+                }
+            )
+            return
+    if latest_month.isoformat() <= state.get("recovered_month", "") or len(counts) != 5:
+        return
+    baseline_sum = sum(counts[month] for month in months[:3])
+    if baseline_sum < 300 or any(
+        counts[month] * 6 > baseline_sum for month in months[-2:]
+    ):
+        return
+    details = {
+        "service_id": service.pk,
+        "report_id": report.pk,
+        "site_url": report.site_url,
+        "detected_month": latest_month.isoformat(),
+        "baseline_sum": baseline_sum,
+        "baseline_average": baseline_sum / 3,
+        "baseline_months": [
+            {"month": month.isoformat(), "changes": counts[month]}
+            for month in months[:3]
+        ],
+        "low_months": [
+            {
+                "month": month.isoformat(),
+                "changes": counts[month],
+                "decrease_percent": 100
+                * (baseline_sum - 3 * counts[month])
+                / baseline_sum,
+            }
+            for month in months[-2:]
+        ],
+        "latest_month": latest_month.isoformat(),
+        "latest_changes": counts[latest_month],
+    }
+    CustomerFollowUp.objects.get_or_create(
+        service=service,
+        type=CustomerFollowUp.Type.ACTIVITY_DROP,
+        defaults={
+            "customer": service.customer,
+            "follow_up_at": timezone.now(),
+            "details": details,
+        },
+    )
+    service.activity_drop_state = details
+    service.save(update_fields=["activity_drop_state"])

--- a/weblate_web/crm/templates/payments/customer_detail.html
+++ b/weblate_web/crm/templates/payments/customer_detail.html
@@ -137,7 +137,22 @@
                 <tr>
                   <td>{% blocktranslate with date=followup.follow_up_at %}Next follow-up: {{ date }}{% endblocktranslate %}</td>
                   <td>{{ followup.get_type_display }}</td>
-                  <td>{{ followup.display_note|default:"-" }}</td>
+                  <td>
+                    {{ followup.display_note|default:"-" }}
+                    {% if followup.is_activity_drop %}
+                      <p><a href="{{ followup.service.get_absolute_url }}">{{ followup.service.site_title }}</a></p>
+                      <p>{% blocktranslate with average=followup.details.baseline_average|floatformat:1 %}Baseline: {{ average }} changes per month.{% endblocktranslate %}</p>
+                      <ul>
+                        {% for month in followup.details.baseline_months %}
+                          <li>{% blocktranslate with month=month.month changes=month.changes %}{{ month }}: {{ changes }} changes{% endblocktranslate %}</li>
+                        {% endfor %}
+                        {% for month in followup.details.low_months %}
+                          <li>{% blocktranslate with month=month.month changes=month.changes decrease=month.decrease_percent|floatformat:1 %}{{ month }}: {{ changes }} changes ({{ decrease }}% decrease){% endblocktranslate %}</li>
+                        {% endfor %}
+                      </ul>
+                      <p>{% blocktranslate with month=followup.details.latest_month changes=followup.details.latest_changes %}Latest activity ({{ month }}): {{ changes }} changes{% endblocktranslate %}</p>
+                    {% endif %}
+                  </td>
                   {% if can_change_customer %}
                     <td>
                       <form method="post">

--- a/weblate_web/forms.py
+++ b/weblate_web/forms.py
@@ -19,11 +19,13 @@
 
 from __future__ import annotations
 
+from datetime import date
 from urllib.parse import quote, urlsplit, urlunsplit
 
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.utils import timezone
 from django.utils.translation import gettext, gettext_lazy
 
 from weblate_web.invoices.models import Currency, InvoiceKind
@@ -99,6 +101,7 @@ class SupportReportForm(forms.ModelForm):
     site_url = forms.CharField(required=False, max_length=SITE_URL_MAX_LENGTH)
     words = forms.IntegerField(required=False)
     strings = forms.IntegerField(required=False)
+    activity = forms.JSONField(required=False)
 
     class Meta:
         model = Report
@@ -125,6 +128,35 @@ class SupportReportForm(forms.ModelForm):
         return normalize_site_url(
             self.cleaned_data.get("site_url", ""), allow_empty=True
         )
+
+    def clean_activity(self) -> dict[date, int]:
+        activity = self.cleaned_data.get("activity")
+        if activity is None or activity == []:
+            return {}
+        error = gettext("Invalid monthly activity data.")
+        if not isinstance(activity, list) or len(activity) > 24:
+            raise ValidationError(error)
+        result: dict[date, int] = {}
+        current_month = timezone.localdate().replace(day=1)
+        for item in activity:
+            if (
+                not isinstance(item, dict)
+                or set(item) != {"year", "month", "changes"}
+                or any(
+                    isinstance(value, bool) or not isinstance(value, int)
+                    for value in item.values()
+                )
+                or not 0 <= item["changes"] <= 2**63 - 1
+            ):
+                raise ValidationError(error)
+            try:
+                month = date(item["year"], item["month"], 1)
+            except (ValueError, OverflowError) as exc:
+                raise ValidationError(error) from exc
+            if month >= current_month or month in result:
+                raise ValidationError(error)
+            result[month] = item["changes"]
+        return dict(sorted(result.items()))
 
     def clean(self):
         cleaned_data = super().clean()

--- a/weblate_web/management/commands/backups_sync.py
+++ b/weblate_web/management/commands/backups_sync.py
@@ -168,7 +168,17 @@ class Command(BaseCommand):
             service.backup_subaccount = 0
             service.backup_size = 0
             service.backup_timestamp = None
-            service.save()
+            service.save(
+                update_fields=[
+                    "backup_removed",
+                    "backup_repository",
+                    "backup_box",
+                    "backup_directory",
+                    "backup_subaccount",
+                    "backup_size",
+                    "backup_timestamp",
+                ]
+            )
 
     def check_unpaid(self, backup_services: dict[str, Service]) -> None:
         for service in backup_services.values():

--- a/weblate_web/migrations/0053_service_activity_drop_state_serviceactivity.py
+++ b/weblate_web/migrations/0053_service_activity_drop_state_serviceactivity.py
@@ -1,0 +1,73 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("weblate_web", "0001_squashed_0052_discoveryactivation"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="service",
+            name="activity_drop_state",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.CreateModel(
+            name="ServiceActivity",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("month", models.DateField()),
+                ("changes", models.PositiveBigIntegerField()),
+                (
+                    "service",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="activity",
+                        to="weblate_web.service",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name_plural": "Service activity",
+                "ordering": ["month"],
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("service", "month"),
+                        name="unique_service_activity_month",
+                    ),
+                    models.CheckConstraint(
+                        condition=models.Q(("month__day", 1)),
+                        name="service_activity_month_start",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/weblate_web/models.py
+++ b/weblate_web/models.py
@@ -781,6 +781,7 @@ class Service(models.Model):  # ruff:ignore[too-many-public-methods]
     site_version = models.TextField(default="", blank=True)
     site_users = models.IntegerField(default=0)
     site_projects = models.IntegerField(default=0)
+    activity_drop_state = models.JSONField(default=dict, blank=True)
 
     discover_text = models.CharField(
         verbose_name=gettext_lazy("Server description"), max_length=200, blank=True
@@ -1196,7 +1197,16 @@ class Service(models.Model):  # ruff:ignore[too-many-public-methods]
             self.limit_hosted_strings = package.limit_hosted_strings
             self.limit_languages = package.limit_languages
             self.limit_projects = package.limit_projects
-            self.save()
+            self.save(
+                update_fields=[
+                    "status",
+                    "limit_source_strings",
+                    "limit_hosted_words",
+                    "limit_hosted_strings",
+                    "limit_languages",
+                    "limit_projects",
+                ]
+            )
 
     def has_paid_backup(self) -> bool:
         subscriptions = self.hosted_subscriptions | self.backup_subscriptions
@@ -1798,6 +1808,29 @@ def add_subscription_past_payments(
         ],
         ignore_conflicts=True,
     )
+
+
+class ServiceActivity(models.Model):
+    service = models.ForeignKey(
+        Service, related_name="activity", on_delete=models.CASCADE
+    )
+    month = models.DateField()
+    changes = models.PositiveBigIntegerField()
+
+    class Meta:
+        ordering = ["month"]
+        verbose_name_plural = "Service activity"
+        constraints = [
+            models.UniqueConstraint(
+                fields=("service", "month"), name="unique_service_activity_month"
+            ),
+            models.CheckConstraint(
+                condition=Q(month__day=1), name="service_activity_month_start"
+            ),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.service_id}: {self.month}: {self.changes}"
 
 
 class Report(models.Model):

--- a/weblate_web/payments/migrations/0007_alter_customerfollowup_type_and_more.py
+++ b/weblate_web/payments/migrations/0007_alter_customerfollowup_type_and_more.py
@@ -1,0 +1,55 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("payments", "0006_customerfollowup_expired_dedicated"),
+        ("weblate_web", "0053_service_activity_drop_state_serviceactivity"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="customerfollowup",
+            name="type",
+            field=models.PositiveSmallIntegerField(
+                choices=[
+                    (1, "Manual"),
+                    (2, "Duplicate payment"),
+                    (3, "Locked site URL"),
+                    (4, "Service over limits"),
+                    (5, "Expired dedicated service"),
+                    (6, "Activity drop"),
+                ],
+                db_index=True,
+                default=1,
+                verbose_name="Follow-up type",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="customerfollowup",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("service__isnull", False), ("type", 6)),
+                fields=("service", "type"),
+                name="unique_activity_drop_followup_per_service",
+            ),
+        ),
+    ]

--- a/weblate_web/payments/models.py
+++ b/weblate_web/payments/models.py
@@ -756,6 +756,7 @@ class CustomerFollowUp(models.Model):
         LOCKED_SITE_URL = 3, gettext_lazy("Locked site URL")
         OVER_LIMIT = 4, gettext_lazy("Service over limits")
         EXPIRED_DEDICATED = 5, gettext_lazy("Expired dedicated service")
+        ACTIVITY_DROP = 6, gettext_lazy("Activity drop")
 
     customer = models.ForeignKey(
         Customer, related_name="followups", on_delete=models.deletion.CASCADE
@@ -795,6 +796,11 @@ class CustomerFollowUp(models.Model):
         constraints = [
             models.UniqueConstraint(
                 fields=("service", "type"),
+                condition=models.Q(service__isnull=False, type=6),
+                name="unique_activity_drop_followup_per_service",
+            ),
+            models.UniqueConstraint(
+                fields=("service", "type"),
                 condition=models.Q(service__isnull=False, type=3),
                 name="unique_locked_site_url_followup_per_service",
             ),
@@ -814,9 +820,15 @@ class CustomerFollowUp(models.Model):
         return f"{self.customer}: {self.note or self.get_type_display()}"
 
     @property
+    def is_activity_drop(self) -> bool:
+        return self.type == self.Type.ACTIVITY_DROP
+
+    @property
     def display_note(self) -> str:
         if self.note:
             return self.note
+        if self.type == self.Type.ACTIVITY_DROP:
+            return gettext("Contact the customer to understand the activity decrease.")
         if self.type == self.Type.OVER_LIMIT:
             return gettext("Review usage and upgrade the dedicated instance.")
         if self.type == self.Type.EXPIRED_DEDICATED:

--- a/weblate_web/test_activity.py
+++ b/weblate_web/test_activity.py
@@ -1,0 +1,581 @@
+# Copyright © Michal Čihař <michal@weblate.org>
+#
+# This file is part of Weblate <https://weblate.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, date, datetime, timedelta
+from threading import Barrier
+from unittest.mock import patch
+
+from dateutil.relativedelta import relativedelta
+from django.contrib.auth.models import User
+from django.db import DataError, IntegrityError, connection, transaction
+from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
+from django.utils import timezone
+from lxml import html
+
+from weblate_web.activity import record_activity
+from weblate_web.forms import SupportReportForm
+from weblate_web.management.commands.backups_sync import Command as BackupsSyncCommand
+from weblate_web.models import (
+    Package,
+    PackageCategory,
+    Report,
+    Service,
+    ServiceKind,
+)
+from weblate_web.payments.models import Customer, CustomerFollowUp
+
+
+class ActivityTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.now = datetime(2026, 9, 10, tzinfo=UTC)
+        self.clock = patch("django.utils.timezone.now", return_value=self.now)
+        self.mock_now = self.clock.start()
+        self.addCleanup(self.clock.stop)
+        self.customer = Customer.objects.create(user_id=-1, origin="activity")
+        self.package = Package.objects.create(
+            name="extended",
+            verbose="Extended support",
+            price=42,
+            category=PackageCategory.PACKAGE_SUPPORT,
+        )
+        Package.objects.create(name="community", verbose="Community support", price=0)
+        self.service = Service.objects.create(
+            customer=self.customer, site_url="https://example.com"
+        )
+        self.subscription = self.service.subscription_set.create(
+            package=self.package, expires=self.now + timedelta(days=365)
+        )
+        self.months = [date(2026, month, 1) for month in range(4, 9)]
+
+    def post_activity(self, activity, **extra):
+        return self.client.post(
+            "/api/support/",
+            {
+                "secret": self.service.secret,
+                "site_url": "https://example.com",
+                "activity": json.dumps(activity),
+                **extra,
+            },
+            headers={"user-agent": "Weblate/2026.10"},
+        )
+
+    def payload(self, counts):
+        return [
+            {"year": month.year, "month": month.month, "changes": changes}
+            for month, changes in zip(self.months, counts, strict=True)
+        ]
+
+    def record(self, counts):
+        report = Report.objects.create(
+            service=self.service, site_url="https://example.com"
+        )
+        record_activity(report, dict(zip(self.months, counts, strict=True)))
+        return report
+
+    def test_storage_and_corrections(self) -> None:
+        months = [
+            date(2024, 9, 1) + relativedelta(months=offset) for offset in range(24)
+        ]
+        payload = [
+            {"year": month.year, "month": month.month, "changes": 100}
+            for month in months
+        ]
+        self.assertEqual(self.post_activity(payload).status_code, 200)
+        self.mock_now.return_value = self.now + relativedelta(months=1)
+        payload = [*payload[1:], {"year": 2026, "month": 9, "changes": 0}]
+        payload[0]["changes"] = 42
+        self.assertEqual(self.post_activity(payload).status_code, 200)
+        self.assertEqual(self.post_activity(payload).status_code, 200)
+        self.assertEqual(self.service.activity.count(), 25)
+        self.assertEqual(self.service.activity.get(month=months[0]).changes, 100)
+        self.assertEqual(self.service.activity.get(month=months[1]).changes, 42)
+        self.assertEqual(self.service.activity.get(month=date(2026, 9, 1)).changes, 0)
+        empty: list[object] | None
+        for empty in (None, []):
+            self.assertEqual(self.post_activity(empty).status_code, 200)
+            self.assertEqual(self.service.activity.count(), 25)
+        response = self.client.post(
+            "/api/support/",
+            {"secret": self.service.secret},
+            headers={"user-agent": "Weblate/5.0"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.service.activity.count(), 25)
+
+    def test_validation(self) -> None:
+        good = {"year": 2026, "month": 8, "changes": 10}
+        invalid = [
+            {},
+            0,
+            False,
+            "invalid",
+            [good, good],
+            [good] * 25,
+            [{**good, "changes": -1}],
+            [{**good, "changes": True}],
+            [{**good, "changes": 1.5}],
+            [{**good, "changes": 2**63}],
+            [{**good, "month": 13}],
+            [{**good, "year": 0}],
+            [{**good, "month": 9}],
+            [{**good, "year": 2027}],
+            [{"year": 2026}],
+            [{**good, "extra": 1}],
+        ]
+        for payload in invalid:
+            with self.subTest(payload=payload):
+                self.assertEqual(self.post_activity(payload).status_code, 400)
+        self.assertFalse(SupportReportForm({"activity": "{"}).is_valid())
+        self.assertFalse(self.service.activity.exists())
+        self.assertFalse(self.service.report_set.exists())
+
+    def test_locked_url(self) -> None:
+        self.service.site_url_lock = True
+        self.service.save(update_fields=["site_url_lock"])
+        response = self.post_activity(
+            self.payload([100, 100, 100, 0, 0]), site_url="https://wrong.example.com"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(self.service.activity.exists())
+        self.assertFalse(
+            self.service.followups.filter(
+                type=CustomerFollowUp.Type.ACTIVITY_DROP
+            ).exists()
+        )
+
+    def test_drop_boundaries(self) -> None:
+        for counts, expected in (
+            ([100, 100, 100, 50, 50], True),
+            ([99, 99, 99, 0, 0], False),
+            ([100, 100, 100, 51, 0], False),
+            ([100, 100, 100, 0, 51], False),
+            ([0, 0, 0, 0, 0], False),
+            ([100, 100, 101, 50, 50], True),
+        ):
+            with self.subTest(counts=counts):
+                self.service.followups.all().delete()
+                Service.objects.filter(pk=self.service.pk).update(
+                    activity_drop_state={}
+                )
+                self.record(counts)
+                self.assertEqual(self.service.followups.exists(), expected)
+
+    def test_missing_month_is_not_zero(self) -> None:
+        payload = self.payload([100, 100, 100, 0, 0])
+        self.assertEqual(self.post_activity(payload[:3] + payload[4:]).status_code, 200)
+        self.assertFalse(self.service.followups.exists())
+        self.assertEqual(self.post_activity(payload[3:4]).status_code, 200)
+        self.assertTrue(self.service.followups.exists())
+
+    def test_episode_lifecycle(self) -> None:
+        self.record([100, 100, 100, 50, 0])
+        followup = self.service.followups.get()
+        followup.note = "Call next week"
+        followup.follow_up_at = self.now + timedelta(days=7)
+        followup.save()
+        self.record([100, 100, 100, 0, 0])
+        followup.refresh_from_db()
+        self.assertEqual(followup.note, "Call next week")
+        self.assertEqual(followup.follow_up_at, self.now + timedelta(days=7))
+        # Corrected historical counts do not count as recovery.
+        self.record([100, 100, 100, 0, 100])
+        self.assertEqual(self.service.followups.get().pk, followup.pk)
+        followup.delete()
+        self.record([100, 100, 100, 0, 0])
+        self.assertFalse(self.service.followups.exists())
+        # A shrinking rolling baseline must not rearm the episode.
+        self.mock_now.return_value = self.now + relativedelta(months=3)
+        self.months = [month + relativedelta(months=3) for month in self.months]
+        self.record([0, 0, 0, 0, 0])
+        self.service.refresh_from_db()
+        self.assertIn("baseline_sum", self.service.activity_drop_state)
+        self.record([0, 0, 0, 0, 51])
+        self.service.refresh_from_db()
+        self.assertIn("recovered_month", self.service.activity_drop_state)
+        self.mock_now.return_value += relativedelta(months=5)
+        self.months = [month + relativedelta(months=5) for month in self.months]
+        self.record([100, 100, 100, 0, 0])
+        self.assertTrue(self.service.followups.exists())
+
+    def test_backup_removal_preserves_episode(self) -> None:
+        self.service.backup_repository = "backup-repository"
+        self.service.backup_box = 42
+        self.service.backup_directory = "test-backup"
+        self.service.backup_subaccount = 123
+        self.service.save()
+        for state in (
+            {"baseline_sum": 300, "detected_month": "2026-08-01"},
+            {"recovered_month": "2026-09-01"},
+        ):
+            with self.subTest(state=state):
+                # The backup command loaded this service before the report's update.
+                Service.objects.filter(pk=self.service.pk).update(
+                    activity_drop_state=state
+                )
+                with (
+                    patch(
+                        "weblate_web.management.commands.backups_sync.delete_storage_subaccount"
+                    ),
+                    patch("weblate_web.management.commands.backups_sync.sftp_client"),
+                    patch(
+                        "weblate_web.management.commands.backups_sync.remove_directory"
+                    ),
+                ):
+                    BackupsSyncCommand().remove_disabled(
+                        {"backup-repository": self.service}
+                    )
+                updated = Service.objects.get(pk=self.service.pk)
+                self.assertEqual(updated.activity_drop_state, state)
+                self.assertEqual(updated.backup_repository, "")
+                self.assertEqual(updated.backup_removed["directory"], "test-backup")
+                self.service.backup_repository = "backup-repository"
+                self.service.backup_box = 42
+                self.service.backup_directory = "test-backup"
+                self.service.backup_subaccount = 123
+
+    def test_local_month_boundaries(self) -> None:
+        for zone, now, latest in (
+            (
+                "Europe/Prague",
+                datetime(2026, 8, 31, 22, 30, tzinfo=UTC),
+                date(2026, 8, 1),
+            ),
+            (
+                "Europe/Prague",
+                datetime(2026, 12, 31, 23, 30, tzinfo=UTC),
+                date(2026, 12, 1),
+            ),
+            (
+                "America/Los_Angeles",
+                datetime(2026, 9, 1, 1, tzinfo=UTC),
+                date(2026, 7, 1),
+            ),
+        ):
+            with self.subTest(zone=zone, now=now), timezone.override(zone):
+                self.mock_now.return_value = now
+                self.service.activity.all().delete()
+                self.service.followups.all().delete()
+                Service.objects.filter(pk=self.service.pk).update(
+                    activity_drop_state={}
+                )
+                self.months = [
+                    latest - relativedelta(months=offset) for offset in range(4, -1, -1)
+                ]
+                self.assertEqual(
+                    self.post_activity(
+                        self.payload([100, 100, 100, 50, 50]), discoverable="1"
+                    ).status_code,
+                    200,
+                )
+                self.assertEqual(
+                    self.service.followups.get().details["detected_month"],
+                    latest.isoformat(),
+                )
+                current = latest + relativedelta(months=1)
+                self.assertEqual(
+                    self.post_activity(
+                        [{"year": current.year, "month": current.month, "changes": 10}]
+                    ).status_code,
+                    400,
+                )
+                competitor = Service.objects.create(
+                    customer=self.customer, discoverable=True
+                )
+                competitor.activity.create(month=latest, changes=10)
+                competitor.activity.create(
+                    month=latest - relativedelta(months=1), changes=1000
+                )
+                response = self.client.get("/en/discover/")
+                self.assertEqual(
+                    [
+                        service.pk
+                        for service in response.context["discoverable_services"]
+                    ],
+                    [self.service.pk, competitor.pk],
+                )
+                competitor.delete()
+
+    def test_recovery_clears_open_followup(self) -> None:
+        self.record([100, 100, 100, 0, 0])
+        self.mock_now.return_value += relativedelta(months=1)
+        self.months = [month + relativedelta(months=1) for month in self.months]
+        self.record([100, 100, 0, 0, 50])
+        self.assertTrue(self.service.followups.exists())
+        self.record([100, 100, 0, 0, 51])
+        self.assertFalse(self.service.followups.exists())
+
+    def test_status_update_preserves_episode(self) -> None:
+        self.record([100, 100, 100, 0, 0])
+        self.service.followups.all().delete()
+        # Simulate a concurrent report holding a service loaded before the drop.
+        self.service.status = "community"
+        self.service.update_status()
+        self.record([100, 100, 100, 0, 0])
+        self.assertFalse(self.service.followups.exists())
+        self.service.refresh_from_db()
+        self.assertIn("baseline_sum", self.service.activity_drop_state)
+
+    def test_eligibility(self) -> None:
+        for enabled, expired, category, name, kind, expected in (
+            (
+                True,
+                False,
+                PackageCategory.PACKAGE_DEDICATED,
+                "hosted:test",
+                ServiceKind.SERVICE,
+                True,
+            ),
+            (
+                True,
+                False,
+                PackageCategory.PACKAGE_SHARED,
+                "shared:test",
+                ServiceKind.SERVICE,
+                True,
+            ),
+            (
+                True,
+                False,
+                PackageCategory.PACKAGE_NONE,
+                "backup",
+                ServiceKind.SERVICE,
+                True,
+            ),
+            (
+                False,
+                False,
+                PackageCategory.PACKAGE_SUPPORT,
+                "extended",
+                ServiceKind.SERVICE,
+                False,
+            ),
+            (
+                True,
+                True,
+                PackageCategory.PACKAGE_SUPPORT,
+                "extended",
+                ServiceKind.SERVICE,
+                False,
+            ),
+            (
+                True,
+                False,
+                PackageCategory.PACKAGE_DONATION,
+                "donation",
+                ServiceKind.DONATION,
+                False,
+            ),
+            (
+                True,
+                False,
+                PackageCategory.PACKAGE_NONE,
+                "community-test",
+                ServiceKind.SERVICE,
+                False,
+            ),
+        ):
+            with self.subTest(name=name, enabled=enabled, expired=expired):
+                self.service.followups.all().delete()
+                Service.objects.filter(pk=self.service.pk).update(
+                    activity_drop_state={}, kind=kind
+                )
+                self.subscription.enabled = enabled
+                self.subscription.expires = self.now + timedelta(
+                    days=-1 if expired else 365
+                )
+                self.subscription.save()
+                self.package.category = category
+                self.package.name = name
+                self.package.save()
+                self.record([100, 100, 100, 0, 0])
+                self.assertEqual(
+                    self.service.followups.filter(
+                        type=CustomerFollowUp.Type.ACTIVITY_DROP
+                    ).exists(),
+                    expected,
+                )
+        self.subscription.delete()
+        self.record([100, 100, 100, 0, 0])
+        self.assertFalse(
+            self.service.followups.filter(
+                type=CustomerFollowUp.Type.ACTIVITY_DROP
+            ).exists()
+        )
+
+    def test_recovery_during_reporting_gap(self) -> None:
+        self.record([100, 100, 100, 0, 0])
+        original = self.service.followups.get()
+        self.mock_now.return_value += relativedelta(months=5)
+        self.months = [month + relativedelta(months=5) for month in self.months]
+        # The next report contains recovery followed by another sustained drop.
+        self.record([100, 100, 100, 0, 0])
+        self.assertNotEqual(self.service.followups.get().pk, original.pk)
+
+    def test_storage_is_atomic(self) -> None:
+        report = Report.objects.create(service=self.service)
+        with (
+            patch(
+                "weblate_web.activity.reconcile_activity_drop",
+                side_effect=RuntimeError("failure"),
+            ),
+            self.assertRaises(RuntimeError),
+        ):
+            record_activity(
+                report, dict(zip(self.months, [100, 100, 100, 0, 0], strict=True))
+            )
+        self.assertFalse(self.service.activity.exists())
+        self.assertFalse(self.service.followups.exists())
+        self.service.refresh_from_db()
+        self.assertEqual(self.service.activity_drop_state, {})
+
+    def test_constraints(self) -> None:
+        self.service.activity.create(month=date(2026, 8, 1), changes=0)
+        for month, changes in (
+            (date(2026, 8, 1), 1),
+            (date(2026, 7, 2), 1),
+        ):
+            with (
+                self.subTest(month=month, changes=changes),
+                self.assertRaises(IntegrityError),
+                transaction.atomic(),
+            ):
+                self.service.activity.create(month=month, changes=changes)
+        # MariaDB rejects unsigned values with DataError rather than a CHECK error.
+        with self.assertRaises((IntegrityError, DataError)), transaction.atomic():
+            self.service.activity.create(month=date(2026, 7, 1), changes=-1)
+
+    @skipUnlessDBFeature("supports_partial_indexes")
+    def test_followup_constraint(self) -> None:
+        # Automatic report deduplication is tested on every locking backend below.
+        self.record([100, 100, 100, 0, 0])
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            CustomerFollowUp.objects.create(
+                service=self.service,
+                customer=self.customer,
+                type=CustomerFollowUp.Type.ACTIVITY_DROP,
+                follow_up_at=timezone.now(),
+            )
+
+    def test_crm_and_clearing(self) -> None:
+        self.record([100, 100, 100, 50, 0])
+        followup = self.service.followups.get()
+        user = User.objects.create_superuser(
+            "activity-admin", "admin@example.com", "test-password"
+        )
+        self.client.force_login(user)
+        response = self.client.get(self.customer.get_absolute_url())
+        self.assertContains(
+            response, "Contact the customer to understand the activity decrease."
+        )
+        self.assertContains(response, "Baseline: 100.0 changes per month.")
+        self.assertContains(response, "50.0% decrease")
+        self.assertContains(response, self.service.get_absolute_url())
+        # Template loops render no text nodes: the activity list contains only li.
+        document = html.fromstring(response.content)
+        activity_lists = document.xpath("//ul[li[contains(., 'changes')]]")
+        self.assertEqual(len(activity_lists), 1)
+        activity_list = activity_lists[0]
+        self.assertEqual([child.tag for child in activity_list], ["li"] * 5)
+        self.assertFalse((activity_list.text or "").strip())
+        self.assertTrue(all(not (child.tail or "").strip() for child in activity_list))
+        response = self.client.post(
+            self.customer.get_absolute_url(),
+            {"clear_follow_up": "1", "follow_up": followup.pk},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.record([100, 100, 100, 0, 0])
+        self.assertFalse(self.service.followups.exists())
+
+
+class ActivityConcurrencyTest(TransactionTestCase):
+    @skipUnlessDBFeature("has_select_for_update")
+    def test_concurrent_reports(self) -> None:
+        customer = Customer.objects.create(user_id=-1, origin="activity")
+        package = Package.objects.create(
+            name="extended",
+            verbose="Support",
+            price=42,
+            category=PackageCategory.PACKAGE_SUPPORT,
+        )
+        Package.objects.create(name="community", verbose="Community support", price=0)
+        service = Service.objects.create(customer=customer)
+        service.subscription_set.create(
+            package=package, expires=timezone.now() + timedelta(days=365)
+        )
+        report = Report.objects.create(service=service)
+        latest = timezone.localdate().replace(day=1) - relativedelta(months=1)
+        months = [latest - relativedelta(months=offset) for offset in range(4, -1, -1)]
+        activity = dict(zip(months, [100, 100, 100, 0, 0], strict=True))
+        barrier = Barrier(2)
+
+        def submit(_index: int) -> None:
+            try:
+                thread_report = Report.objects.get(pk=report.pk)
+                barrier.wait(timeout=10)
+                record_activity(thread_report, activity)
+            finally:
+                connection.close()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            list(executor.map(submit, range(2)))
+        self.assertEqual(service.activity.count(), 5)
+        self.assertEqual(service.followups.count(), 1)
+
+
+class ActivityDiscoveryTest(TransactionTestCase):
+    # MariaDB full-text searches only see committed project rows.
+    @patch("django.utils.timezone.now", return_value=datetime(2026, 9, 10, tzinfo=UTC))
+    def test_discover_order(self, mock_now) -> None:
+        customer = Customer.objects.create(user_id=-1, origin="activity")
+        services = []
+        for title, changes in (
+            ("Unknown", None),
+            ("Zero", 0),
+            ("B", 10),
+            ("A", 10),
+            ("Most active", 100),
+        ):
+            service = Service.objects.create(
+                customer=customer, discoverable=True, site_title=title
+            )
+            service.project_set.create(
+                name="Matching project",
+                url="/projects/matching/",
+                web="https://example.com",
+            )
+            if changes is not None:
+                service.activity.create(month=date(2026, 8, 1), changes=changes)
+            services.append(service)
+        services[0].activity.create(month=date(2026, 7, 1), changes=1000)
+        for query in ("", "?q=matching"):
+            response = self.client.get(f"/en/discover/{query}")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                [service.pk for service in response.context["discoverable_services"]],
+                [service.pk for service in reversed(services)],
+            )
+        mock_now.return_value = datetime(2027, 1, 5, tzinfo=UTC)
+        services[0].activity.create(month=date(2026, 12, 1), changes=1)
+        response = self.client.get("/en/discover/")
+        self.assertEqual(
+            next(iter(response.context["discoverable_services"])), services[0]
+        )

--- a/weblate_web/views.py
+++ b/weblate_web/views.py
@@ -36,7 +36,7 @@ from django.core.exceptions import BadRequest, SuspiciousOperation, ValidationEr
 from django.core.mail import mail_admins
 from django.core.signing import BadSignature, SignatureExpired, loads
 from django.db import DataError, IntegrityError, connection, transaction
-from django.db.models import Q
+from django.db.models import F, OuterRef, Q, Subquery
 from django.http import (
     FileResponse,
     Http404,
@@ -56,6 +56,7 @@ from django.views.generic.dates import ArchiveIndexView
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import CreateView, FormView, UpdateView
 
+from weblate_web.activity import record_activity
 from weblate_web.crm.models import Interaction
 from weblate_web.forms import (
     AddDiscoveryForm,
@@ -81,6 +82,7 @@ from weblate_web.models import (
     Post,
     Project,
     Service,
+    ServiceActivity,
     Subscription,
     UnprocessablePaymentError,
     add_subscription_past_payments,
@@ -365,6 +367,8 @@ def api_support(request: HttpRequest) -> JsonResponse:
     service.update_status()
     report.save()
     is_valid_site_url = report.is_valid_site_url()
+    if is_valid_site_url and form.cleaned_data["activity"]:
+        record_activity(report, form.cleaned_data["activity"])
     service.create_backup()
     if is_valid_site_url and "public_projects" in request.POST:
         current_projects = set(service.project_set.values_list("name", "url", "web"))
@@ -1375,8 +1379,25 @@ class DiscoverView(TemplateView):
         services: Iterable[Service]
         projects: Iterable[Project]
 
-        discoverable_services = Service.objects.customer_services().filter(
-            discoverable=True
+        last_month = (timezone.localdate().replace(day=1) - timedelta(days=1)).replace(
+            day=1
+        )
+        discoverable_services = (
+            Service.objects.customer_services()
+            .filter(discoverable=True)
+            .annotate(
+                monthly_changes=Subquery(
+                    ServiceActivity.objects.filter(
+                        service_id=OuterRef("pk"), month=last_month
+                    ).values("changes")[:1]
+                )
+            )
+            .order_by(
+                F("monthly_changes").desc(nulls_last=True),
+                "site_title",
+                "site_url",
+                "pk",
+            )
         )
         services = discoverable_services.prefetch_related("project_set")
         query = self.request.GET.get("q", "").strip().lower()
@@ -1395,7 +1416,9 @@ class DiscoverView(TemplateView):
                     service.matched_projects = []
                 service.matched_projects.append(project)
 
-            services = list(services_dict.values())
+            services = list(discoverable_services.filter(pk__in=services_dict))
+            for service in services:
+                service.matched_projects = services_dict[service.pk].matched_projects
         else:
             for service in services:
                 projects = list(service.project_set.all())


### PR DESCRIPTION
Store monthly activity history, rank Discover by the latest completed month, and create actionable customer follow-ups for sustained activity drops.

Matches the instance reporting payload introduced in https://github.com/WeblateOrg/weblate/pull/21572

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
